### PR TITLE
Initial release of phyx.js as an npm package

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,13 @@
         "mocha"
     ],
     "rules": {
-      "prefer-destructuring": "off"
+      "prefer-destructuring": "off",
+      "comma-dangle": ["error", {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "ignore"
+      }]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+    "extends": [
+        "airbnb-base",
+        "plugin:mocha/recommended"
+    ],
+    "parserOptions": {
+        "parser": "babel-eslint",
+        "ecmaVersion": 6,
+        "sourceType": "module"
+    },
+    "env": {
+        "es6": true
+    },
+    "plugins": [
+        "mocha"
+    ],
+    "rules": {
+      "prefer-destructuring": "off"
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# Based on blog post https://medium.freecodecamp.org/how-to-stop-errors-before-they-ever-hit-your-codebase-with-travis-ci-and-eslint-7a5a6b1fcd4a
+
+language: node_js
+
+node_js:
+  - '10'
+
+before_install: if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
+
+cache:
+  directories:
+    - node_modules
+
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@
 language: node_js
 
 node_js:
-  - '10'
+  - 'lts/*' # Check against all long-term support Node releases.
+  - 'node' # Check against the latest stable Node release.
 
 before_install: if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@
 language: node_js
 
 node_js:
-  - 'node' # Check against the latest stable Node release, currently: 11.x
-  - 'lts/*' # Check against the active long-term support (LTS), currently: 10.x
-  - '11' # Current release
-  - '10' # Active LTS until April 2020 (according to https://github.com/nodejs/Release)
+  - '11' # Current release (according to https://github.com/nodejs/Release)
+  - '10' # Active LTS until April 2020
   - '8' # Maintenance LTS until December 2019
   - '6' # Maintenance LTS until April 2019
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,12 @@
 language: node_js
 
 node_js:
-  - 'lts/*' # Check against all long-term support Node releases.
-  - 'node' # Check against the latest stable Node release.
+  - 'node' # Check against the latest stable Node release, currently: 11.x
+  - 'lts/*' # Check against the active long-term support (LTS), currently: 10.x
+  - '11' # Current release
+  - '10' # Active LTS until April 2020 (according to https://github.com/nodejs/Release)
+  - '8' # Maintenance LTS until December 2019
+  - '6' # Maintenance LTS until April 2019
 
 before_install: if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this library will be documented in this file.
+
+The format is based on [Keep a Changelog] and this project adheres to [Semantic Versioning].
+
+## 0.1.0 - 2019-01-27
+### Added
+- Transfered initial code from the [Phyloreference Curation Tool]. The initial
+release of this package was based on [commit 14d2c3d5d1] in that repository.
+
+### Changed
+- Replaced references to the [phylotree] library with the [newick-js] library.
+- Made other changes to the initial code as needed to work as an independent NPM package.
+
+  [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+  [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+  [Phyloreference Curation Tool]: http://github.com/phyloref/curation-tool
+  [commit 14d2c3d5d1]: https://github.com/phyloref/curation-tool/commit/14d2c3d5d12ee4e925e29961bd46587aabfb8cd4
+  [phylotree]: https://www.npmjs.com/package/phylotree
+  [newick-js]: https://www.npmjs.com/package/newick-js

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # phyx.js
-Phyloreference Exchange (PHYX) library in JavaScript
 
-## Initial development
-This package was initially developed as part of the [Curation Tool]. The initial
-release of this package was based on [commit 14d2c3d5d1] in that repository.
+The Phyloreference Exchange (PHYX) format is a JSON representation that can be
+used to store and transfer definitions of [phyloreferences]. This library provides
+classes to help interpret some parts of these files, and for transforming an
+entire Phyx file into a [JSON-LD] representation that can be reasoned over with
+an [OWL 2 DL] reasoner. See the [Phyloreference Curation Tool] or the [Clade Ontology]
+for examples of its usage.
 
-[Curation Tool]: http://github.com/phyloref/curation-tool
-[commit 14d2c3d5d1]: https://github.com/phyloref/curation-tool/commit/14d2c3d5d12ee4e925e29961bd46587aabfb8cd4
+  [phyloreferences]: http://phyloref.org
+  [JSON-LD]: https://en.wikipedia.org/wiki/JSON-LD
+  [OWL 2 DL]: https://www.w3.org/TR/owl2-overview/
+  [Phyloreference Curation Tool]: https://github.com/phyloref/curation-tool
+  [Clade Ontology]: https://github.com/phyloref/clade-ontology

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # phyx.js
 Phyloreference Exchange (PHYX) library in JavaScript
+
+## Initial development
+This package was initially developed as part of the [Curation Tool]. The initial
+release of this package was based on [commit 14d2c3d5d1] in that repository.
+
+[Curation Tool]: http://github.com/phyloref/curation-tool
+[commit 14d2c3d5d1]: https://github.com/phyloref/curation-tool/commit/14d2c3d5d12ee4e925e29961bd46587aabfb8cd4

--- a/README.md
+++ b/README.md
@@ -7,8 +7,15 @@ entire Phyx file into a [JSON-LD] representation that can be reasoned over with
 an [OWL 2 DL] reasoner. See the [Phyloreference Curation Tool] or the [Clade Ontology]
 for examples of its usage.
 
+## Funding
+Funded by the US National Science Foundation through collaborative grants [DBI-1458484]
+and [DBI-1458604]. See [Funding] for details.
+
   [phyloreferences]: http://phyloref.org
   [JSON-LD]: https://en.wikipedia.org/wiki/JSON-LD
   [OWL 2 DL]: https://www.w3.org/TR/owl2-overview/
   [Phyloreference Curation Tool]: https://github.com/phyloref/curation-tool
   [Clade Ontology]: https://github.com/phyloref/clade-ontology
+  [DBI-1458484]: http://www.nsf.gov/awardsearch/showAward?AWD_ID=1458484
+  [DBI-1458604]: http://www.nsf.gov/awardsearch/showAward?AWD_ID=1458604
+  [Funding]: http://www.phyloref.org/about/#funding

--- a/index.js
+++ b/index.js
@@ -471,9 +471,9 @@ class TaxonomicUnitMatcher {
   match() {
     // Try to match the two taxonomic units using a number of matching methods.
     if (
-      this.matchByBinomialName() ||
-      this.matchByExternalReferences() ||
-      this.matchBySpecimenIdentifier()
+      this.matchByBinomialName()
+      || this.matchByExternalReferences()
+      || this.matchBySpecimenIdentifier()
     ) {
       this.matched = true;
     } else {
@@ -493,10 +493,10 @@ class TaxonomicUnitMatcher {
       return this.tunit2.scientificNames.some((scname2) => {
         const scname2wrapped = new ScientificNameWrapper(scname2);
 
-        const result = scname1wrapped.binomialName !== undefined &&
-          scname2wrapped.binomialName !== undefined &&
-          scname1wrapped.binomialName.trim().length > 0 &&
-          scname1wrapped.binomialName.trim() === scname2wrapped.binomialName.trim();
+        const result = scname1wrapped.binomialName !== undefined
+          && scname2wrapped.binomialName !== undefined
+          && scname1wrapped.binomialName.trim().length > 0
+          && scname1wrapped.binomialName.trim() === scname2wrapped.binomialName.trim();
 
         if (result) {
           this.matchReason = `Scientific name '${scname1wrapped.scientificName}' and scientific name '${scname2wrapped.scientificName}' share the same binomial name`;
@@ -528,7 +528,7 @@ class TaxonomicUnitMatcher {
           }
 
           return result;
-        }),
+        })
       );
     }
 
@@ -613,9 +613,9 @@ class PhylogenyWrapper {
     if (parenLevels !== 0) {
       errors.push({
         title: 'Unbalanced parentheses in Newick string',
-        message: (parenLevels > 0 ?
-          `You have ${parenLevels} too many open parentheses` :
-          `You have ${-parenLevels} too few open parentheses`
+        message: (parenLevels > 0
+          ? `You have ${parenLevels} too many open parentheses`
+          : `You have ${-parenLevels} too few open parentheses`
         ),
       });
     }
@@ -659,7 +659,7 @@ class PhylogenyWrapper {
           child,
           func,
           nextID,
-          nodeCount,
+          nodeCount
         );
       });
     }
@@ -684,7 +684,7 @@ class PhylogenyWrapper {
 
     nodeLabels.forEach(
       nodeLabel => this.getTaxonomicUnitsForNodeLabel(nodeLabel)
-        .forEach(tunit => tunits.add(tunit)),
+        .forEach(tunit => tunits.add(tunit))
     );
 
     return tunits;
@@ -708,8 +708,8 @@ class PhylogenyWrapper {
         new Set(
           Array.from(vertices)
             .map(vertex => vertex.label)
-            .filter(label => label !== undefined),
-        ),
+            .filter(label => label !== undefined)
+        )
       );
     }
 
@@ -718,7 +718,7 @@ class PhylogenyWrapper {
       return Array.from(new Set(
         Array.from(arcs)
           .map(arc => arc[0].label) // Retrieve the label of the parent vertex in this arc.
-          .filter(label => label !== undefined),
+          .filter(label => label !== undefined)
       ));
     }
 
@@ -747,8 +747,8 @@ class PhylogenyWrapper {
     // Look up additional node properties.
     let additionalNodeProperties = {};
     if (
-      hasOwnProperty(this.phylogeny, 'additionalNodeProperties') &&
-      hasOwnProperty(this.phylogeny.additionalNodeProperties, nodeLabel)
+      hasOwnProperty(this.phylogeny, 'additionalNodeProperties')
+      && hasOwnProperty(this.phylogeny.additionalNodeProperties, nodeLabel)
     ) {
       additionalNodeProperties = this.phylogeny.additionalNodeProperties[nodeLabel];
     }
@@ -783,8 +783,8 @@ class PhylogenyWrapper {
       // and associated with the node.
       return specifierTUnits.some(
         tunit1 => nodeTUnits.some(
-          tunit2 => new TaxonomicUnitMatcher(tunit1, tunit2).matched,
-        ),
+          tunit2 => new TaxonomicUnitMatcher(tunit1, tunit2).matched
+        )
       );
     });
   }
@@ -944,12 +944,12 @@ class PhylorefWrapper {
     // if (!hasOwnProperty(this.phyloref, 'internalSpecifiers'))
     //  Vue.set(this.phyloref, 'internalSpecifiers', []);
     if (!hasOwnProperty(this.phyloref, 'internalSpecifiers')) {
-        this.phyloref.internalSpecifiers = [];
+      this.phyloref.internalSpecifiers = [];
     }
     // if (!hasOwnProperty(this.phyloref, 'externalSpecifiers'))
     //  Vue.set(this.phyloref, 'externalSpecifiers', []);
     if (!hasOwnProperty(this.phyloref, 'externalSpecifiers')) {
-        this.phyloref.externalSpecifiers = [];
+      this.phyloref.externalSpecifiers = [];
     }
   }
 
@@ -1078,9 +1078,9 @@ class PhylorefWrapper {
       if (nodeLabel === phylorefLabel) {
         nodeLabels.add(nodeLabel);
       } else if (
-        hasOwnProperty(phylogeny, 'additionalNodeProperties') &&
-        hasOwnProperty(phylogeny.additionalNodeProperties, nodeLabel) &&
-        hasOwnProperty(phylogeny.additionalNodeProperties[nodeLabel], 'expectedPhyloreferenceNamed')
+        hasOwnProperty(phylogeny, 'additionalNodeProperties')
+        && hasOwnProperty(phylogeny.additionalNodeProperties, nodeLabel)
+        && hasOwnProperty(phylogeny.additionalNodeProperties[nodeLabel], 'expectedPhyloreferenceNamed')
       ) {
         // Does this node label have an expectedPhyloreferenceNamed that
         // includes this phyloreference name?
@@ -1119,9 +1119,9 @@ class PhylorefWrapper {
     //  - intervalEnd: the end of the interval
 
     if (
-      hasOwnProperty(this.phyloref, 'pso:holdsStatusInTime') &&
-      Array.isArray(this.phyloref['pso:holdsStatusInTime']) &&
-      this.phyloref['pso:holdsStatusInTime'].length > 0
+      hasOwnProperty(this.phyloref, 'pso:holdsStatusInTime')
+      && Array.isArray(this.phyloref['pso:holdsStatusInTime'])
+      && this.phyloref['pso:holdsStatusInTime'].length > 0
     ) {
       // If we have any pso:holdsStatusInTime entries, pick the first one and
       // extract the CURIE and time interval information from it.
@@ -1206,15 +1206,15 @@ class PhylorefWrapper {
 
     // Check to see if there's a previous time interval we should end.
     if (
-      Array.isArray(this.phyloref['pso:holdsStatusInTime']) &&
-      this.phyloref['pso:holdsStatusInTime'].length > 0
+      Array.isArray(this.phyloref['pso:holdsStatusInTime'])
+      && this.phyloref['pso:holdsStatusInTime'].length > 0
     ) {
       const lastStatusInTime = this.phyloref['pso:holdsStatusInTime'][this.phyloref['pso:holdsStatusInTime'].length - 1];
 
       // if (!hasOwnProperty(lastStatusInTime, 'tvc:atTime'))
       //  Vue.set(lastStatusInTime, 'tvc:atTime', {});
       if (!hasOwnProperty(lastStatusInTime, 'tvc:atTime')) {
-          lastStatusInTime['tvc:atTime'] = {};
+        lastStatusInTime['tvc:atTime'] = {};
       }
       if (!hasOwnProperty(lastStatusInTime['tvc:atTime'], 'timeinterval:hasIntervalEndDate')) {
         // If the last time entry doesn't already have an interval end date, set it to now.
@@ -1340,7 +1340,7 @@ class PhylorefWrapper {
         phylorefURI,
         phylorefAsJSONLD.hasAdditionalClass,
         phylorefAsJSONLD.internalSpecifiers[0],
-        phylorefAsJSONLD.internalSpecifiers[1],
+        phylorefAsJSONLD.internalSpecifiers[1]
       );
 
       for (let index = 2; index < internalSpecifierCount; index += 1) {
@@ -1348,7 +1348,7 @@ class PhylorefWrapper {
           phylorefURI,
           phylorefAsJSONLD.hasAdditionalClass,
           equivalentClassAccumulator,
-          phylorefAsJSONLD.internalSpecifiers[index],
+          phylorefAsJSONLD.internalSpecifiers[index]
         );
       }
 
@@ -1566,7 +1566,7 @@ class PHYXWrapper {
     if (hasOwnProperty(jsonld, 'phylogenies')) {
       jsonld.phylogenies = jsonld.phylogenies.map(
         (phylogeny, countPhylogeny) => new PhylogenyWrapper(phylogeny)
-          .asJSONLD(PHYXWrapper.getBaseURIForPhylogeny(countPhylogeny), this.newickParser),
+          .asJSONLD(PHYXWrapper.getBaseURIForPhylogeny(countPhylogeny), this.newickParser)
       );
     }
 
@@ -1574,7 +1574,7 @@ class PHYXWrapper {
     if (hasOwnProperty(jsonld, 'phylorefs')) {
       jsonld.phylorefs = jsonld.phylorefs.map(
         (phyloref, countPhyloref) => new PhylorefWrapper(phyloref)
-          .asJSONLD(PHYXWrapper.getBaseURIForPhyloref(countPhyloref)),
+          .asJSONLD(PHYXWrapper.getBaseURIForPhyloref(countPhyloref))
       );
     }
 
@@ -1613,8 +1613,9 @@ class PHYXWrapper {
                 nodeTUs.forEach((nodeTU) => {
                   const matcher = new TaxonomicUnitMatcher(specifierTU, nodeTU);
                   if (matcher.matched) {
-                    const tuMatchAsJSONLD =
-                      matcher.asJSONLD(PHYXWrapper.getBaseURIForTUMatch(countTaxonomicUnitMatches));
+                    const tuMatchAsJSONLD = matcher.asJSONLD(
+                      PHYXWrapper.getBaseURIForTUMatch(countTaxonomicUnitMatches)
+                    );
                     jsonld.hasTaxonomicUnitMatches.push(tuMatchAsJSONLD);
                     nodesMatchedCount += 1;
                     countTaxonomicUnitMatches += 1;

--- a/index.js
+++ b/index.js
@@ -24,10 +24,10 @@
 const { parse: parseNewick } = require('newick-js');
 
 // Used to parse timestamps for phyloref statuses.
-import moment from 'moment';
+const moment = require('moment');
 
 // Used to make deep copies of objects.
-import extend from 'extend';
+const extend = require('extend');
 
 // Some OWL constants to be used.
 const CDAO_HAS_CHILD = 'obo:CDAO_0000149';

--- a/index.js
+++ b/index.js
@@ -66,8 +66,8 @@ class CacheManager {
 
   has(cacheName, cacheKey) {
     // Return true if we have a value for this particular cache key.
-    return hasOwnProperty(this.caches, cacheName) &&
-      hasOwnProperty(this.caches[cacheName], cacheKey);
+    return hasOwnProperty(this.caches, cacheName)
+      && hasOwnProperty(this.caches[cacheName], cacheKey);
   }
 
   get(cacheName, cacheKey) {
@@ -513,14 +513,14 @@ class TaxonomicUnitMatcher {
     if (hasOwnProperty(this.tunit1, 'externalReferences') && hasOwnProperty(this.tunit2, 'externalReferences')) {
       // Each external reference is a URL as a string. We will lowercase it,
       // but do no other transformation.
-      return this.tunit1.externalReferences.some(extref1 =>
-        this.tunit2.externalReferences.some((extref2) => {
+      return this.tunit1.externalReferences.some(
+        extref1 => this.tunit2.externalReferences.some((extref2) => {
           const result = (
             // Make sure that the external reference isn't blank
-            extref1.trim() !== '' &&
+            extref1.trim() !== ''
 
-            // And that it is identical after trimming
-            extref1.toLowerCase().trim() === extref2.toLowerCase().trim()
+              // And that it is identical after trimming
+              && extref1.toLowerCase().trim() === extref2.toLowerCase().trim()
           );
 
           if (result) {
@@ -528,7 +528,8 @@ class TaxonomicUnitMatcher {
           }
 
           return result;
-        }));
+        }),
+      );
     }
 
     return false;
@@ -681,8 +682,10 @@ class PhylogenyWrapper {
     const nodeLabels = this.getNodeLabels(nodeType);
     const tunits = new Set();
 
-    nodeLabels.forEach(nodeLabel =>
-      this.getTaxonomicUnitsForNodeLabel(nodeLabel).forEach(tunit => tunits.add(tunit)));
+    nodeLabels.forEach(
+      nodeLabel => this.getTaxonomicUnitsForNodeLabel(nodeLabel)
+        .forEach(tunit => tunits.add(tunit)),
+    );
 
     return tunits;
   }
@@ -778,8 +781,11 @@ class PhylogenyWrapper {
 
       // Attempt pairwise matches between taxonomic units in the specifier
       // and associated with the node.
-      return specifierTUnits.some(tunit1 =>
-        nodeTUnits.some(tunit2 => new TaxonomicUnitMatcher(tunit1, tunit2).matched));
+      return specifierTUnits.some(
+        tunit1 => nodeTUnits.some(
+          tunit2 => new TaxonomicUnitMatcher(tunit1, tunit2).matched,
+        ),
+      );
     });
   }
 
@@ -936,11 +942,13 @@ class PhylorefWrapper {
     this.phyloref = phyloref;
 
     // Reset internal and external specifiers if needed.
-    // if (!hasOwnProperty(this.phyloref, 'internalSpecifiers')) Vue.set(this.phyloref, 'internalSpecifiers', []);
+    // if (!hasOwnProperty(this.phyloref, 'internalSpecifiers'))
+    //  Vue.set(this.phyloref, 'internalSpecifiers', []);
     if (!hasOwnProperty(this.phyloref, 'internalSpecifiers')) {
         this.phyloref.internalSpecifiers = [];
     }
-    // if (!hasOwnProperty(this.phyloref, 'externalSpecifiers')) Vue.set(this.phyloref, 'externalSpecifiers', []);
+    // if (!hasOwnProperty(this.phyloref, 'externalSpecifiers'))
+    //  Vue.set(this.phyloref, 'externalSpecifiers', []);
     if (!hasOwnProperty(this.phyloref, 'externalSpecifiers')) {
         this.phyloref.externalSpecifiers = [];
     }
@@ -1204,7 +1212,8 @@ class PhylorefWrapper {
     ) {
       const lastStatusInTime = this.phyloref['pso:holdsStatusInTime'][this.phyloref['pso:holdsStatusInTime'].length - 1];
 
-      // if (!hasOwnProperty(lastStatusInTime, 'tvc:atTime')) Vue.set(lastStatusInTime, 'tvc:atTime', {});
+      // if (!hasOwnProperty(lastStatusInTime, 'tvc:atTime'))
+      //  Vue.set(lastStatusInTime, 'tvc:atTime', {});
       if (!hasOwnProperty(lastStatusInTime, 'tvc:atTime')) {
           lastStatusInTime['tvc:atTime'] = {};
       }
@@ -1549,15 +1558,18 @@ class PHYXWrapper {
 
     // Add descriptions for individual nodes in each phylogeny.
     if (hasOwnProperty(jsonld, 'phylogenies')) {
-      jsonld.phylogenies = jsonld.phylogenies.map((phylogeny, countPhylogeny) =>
-        new PhylogenyWrapper(phylogeny)
-          .asJSONLD(PHYXWrapper.getBaseURIForPhylogeny(countPhylogeny)));
+      jsonld.phylogenies = jsonld.phylogenies.map(
+        (phylogeny, countPhylogeny) => new PhylogenyWrapper(phylogeny)
+          .asJSONLD(PHYXWrapper.getBaseURIForPhylogeny(countPhylogeny)),
+      );
     }
 
     // Convert phyloreferences into an OWL class restriction
     if (hasOwnProperty(jsonld, 'phylorefs')) {
-      jsonld.phylorefs = jsonld.phylorefs.map((phyloref, countPhyloref) =>
-        new PhylorefWrapper(phyloref).asJSONLD(PHYXWrapper.getBaseURIForPhyloref(countPhyloref)));
+      jsonld.phylorefs = jsonld.phylorefs.map(
+        (phyloref, countPhyloref) => new PhylorefWrapper(phyloref)
+          .asJSONLD(PHYXWrapper.getBaseURIForPhyloref(countPhyloref)),
+      );
     }
 
     // Match all specifiers with nodes.

--- a/index.js
+++ b/index.js
@@ -933,7 +933,6 @@ class PhylogenyWrapper {
 
 /* Phyloreference wrapper */
 
-// eslint-disable-next-line no-unused-vars
 class PhylorefWrapper {
   // Wraps a phyloreference in a PHYX model.
 
@@ -1514,7 +1513,6 @@ class PhylorefWrapper {
 
 /* PHYX file wrapper */
 
-// eslint-disable-next-line no-unused-vars
 class PHYXWrapper {
   // Wraps an entire PHYX document.
 
@@ -1657,15 +1655,13 @@ class PHYXWrapper {
 }
 
 /* Exports */
-if (!hasOwnProperty(this, 'window')) {
-  module.exports = {
-    ScientificNameWrapper,
-    SpecimenWrapper,
-    TaxonomicUnitWrapper,
-    TaxonomicUnitMatcher,
-    PhylogenyWrapper,
-    PhylorefWrapper,
-    PHYXWrapper,
-    phyxCacheManager,
-  };
-}
+module.exports = {
+  ScientificNameWrapper,
+  SpecimenWrapper,
+  TaxonomicUnitWrapper,
+  TaxonomicUnitMatcher,
+  PhylogenyWrapper,
+  PhylorefWrapper,
+  PHYXWrapper,
+  phyxCacheManager,
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1637 @@
+/*
+ * PHYX Library
+ * Copyright (c) The Phyloreferencing Project, 2018-19
+ *
+ * PHYloreference eXchange (PHYX) files store phyloreferences along with
+ * annotated phylogenies that allow their expected resolution to be curated
+ * and tested. This library provides classes and methods that help read and
+ * manipulate components of PHYX files.
+ *
+ * Note that our goal here isn't to provide a library for modeling an entire
+ * PHYX file in Javascript. The Curation Tool can mostly access and edit
+ * components of the PHYX file as text strings or JSON objects, and the terms
+ * used in the PHYX file should be clearly defined on their own. This library
+ * contains convenience classes and methods that make accessing those components
+ * easier.
+ *
+ * Most of these classes are wrappers. Because the object they wrap may be
+ * unexpectedly modified through the UI, wrapper constructors should be extremely
+ * lightweight so that the wrapper can be created quickly. Individual methods
+ * can be complex and slow if necessary.
+ */
+
+// TODO: remove references to Vue but make sure it still works from within Vue.
+import phylotree from 'phylotree';
+    // TODO: phylotree requires bootstrap, which seems excessive, but our
+    // current code is designed to work on its particular internal structure.
+    // It might be worth moving that code into the Curation Tool, and replacing
+    // this prerequestive with https://www.npmjs.com/package/newick-js
+import moment from 'moment';
+import extend from 'extend';
+
+// Some OWL constants to be used.
+const CDAO_HAS_CHILD = 'obo:CDAO_0000149';
+const CDAO_HAS_DESCENDANT = 'obo:CDAO_0000174';
+const PHYLOREF_EXCLUDES_LINEAGE_TO = 'phyloref:excludes_lineage_to';
+const PHYLOREFERENCE_TEST_CASE = 'testcase:PhyloreferenceTestCase';
+const PHYLOREFERENCE_PHYLOGENY = 'testcase:PhyloreferenceTestPhylogeny';
+const TESTCASE_SPECIFIER = 'testcase:Specifier';
+
+// Our global variables
+// eslint-disable-next-line no-var
+var phyxCacheManager;
+
+/* Helper methods */
+
+function hasOwnProperty(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+/* Cache manager */
+
+class CacheManager {
+  // The Cache Manager helps manage the various caches we use in this library
+  // Ideally, caches should be created in the global phyxCacheManager object.
+  // A library can then call phyxCacheManager.clear() to empty the entire cache.
+
+  constructor() {
+    // Construct a new cache manager.
+    this.clear();
+  }
+
+  clear() {
+    // Clear all current caches
+    this.caches = {};
+  }
+
+  has(cacheName, cacheKey) {
+    // Return true if we have a value for this particular cache key.
+    return hasOwnProperty(this.caches, cacheName) &&
+      hasOwnProperty(this.caches[cacheName], cacheKey);
+  }
+
+  get(cacheName, cacheKey) {
+    // Look up the value of a key in a particular cache key.
+    if (!hasOwnProperty(this.caches, cacheName)) this.caches[cacheName] = {};
+    if (!hasOwnProperty(this.caches[cacheName], cacheKey)) return undefined;
+    return this.caches[cacheName][cacheKey];
+  }
+
+  put(cacheName, cacheKey, value) {
+    // Set the value of a key in a particular cache key.
+    if (!hasOwnProperty(this.caches, cacheName)) this.caches[cacheName] = {};
+    if (!hasOwnProperty(this.caches[cacheName], cacheKey)) this.caches[cacheName][cacheKey] = {};
+    this.caches[cacheName][cacheKey] = value;
+  }
+}
+phyxCacheManager = new CacheManager();
+
+/* Scientific name processing */
+
+class ScientificNameWrapper {
+  // Wraps a scientific name to provide access to components of
+  // the scientific name. For now, we ignore binomialName, genus and
+  // specificEpithet and rederive them from the scientific name.
+
+  constructor(scname) {
+    // Create a new scientific name wrapper around the JSON representation of
+    // a scientific name.
+    this.scname = scname;
+  }
+
+  static createFromVerbatimName(verbatimName) {
+    // Returns a scientific name object created from a particular verbatim name.
+    // Not that the returned object will NOT be wrapped -- so remember to wrap it
+    // if necessary!
+
+    // Start with the 'scientific name' as the verbatim name.
+    const scname = {
+      scientificName: verbatimName,
+    };
+
+    // Split the verbatim name into a genus and specific epithet, if possible.
+    // Splitting the verbatim name takes some time, so let's memoize this.
+    if (phyxCacheManager.has('ScientificNameWrapper.scnameCache', verbatimName)) {
+      return phyxCacheManager.get('ScientificNameWrapper.scnameCache', verbatimName);
+    }
+
+    const comps = verbatimName.split(/\s+/);
+
+    // Did we find a binomial?
+    if (comps.length >= 2) {
+      [, scname.specificEpithet] = comps;
+    }
+
+    // Did we find a uninomial?
+    if (comps.length >= 1) {
+      [scname.genus] = comps;
+    }
+
+    // Store in the cache.
+    phyxCacheManager.put('ScientificNameWrapper.scnameCache', verbatimName, scname);
+
+    return scname;
+  }
+
+  get scientificName() {
+    // Get the "dwc:scientificName" -- the complete scientific name.
+    return this.scname.scientificName;
+  }
+
+  get binomialName() {
+    // Get the binomial name. Constructed from the genus and specific epithet
+    // if available.
+    if (this.genus === undefined || this.specificEpithet === undefined) return undefined;
+    return `${this.genus} ${this.specificEpithet}`;
+  }
+
+  get genus() {
+    // Try to read the genus if available.
+    if (hasOwnProperty(this.scname, 'genus')) return this.scname.genus;
+
+    // If there is no genus but there is a scientificName, try to extract a genus
+    // from it.
+    if (hasOwnProperty(this.scname, 'scientificName')) {
+      const scname = ScientificNameWrapper.createFromVerbatimName(this.scname.scientificName);
+      if (hasOwnProperty(scname, 'genus')) return scname.genus;
+    }
+    return undefined;
+  }
+
+  get specificEpithet() {
+    // Try to read the specific epithet if available.
+    if (hasOwnProperty(this.scname, 'specificEpithet')) return this.scname.specificEpithet;
+
+    // If there is no specific epithet but there is a scientificName, try to
+    // extract a specific epithet from it.
+    if (hasOwnProperty(this.scname, 'scientificName')) {
+      const scname = ScientificNameWrapper.createFromVerbatimName(this.scname.scientificName);
+      if (hasOwnProperty(scname, 'specificEpithet')) return scname.specificEpithet;
+    }
+    return undefined;
+  }
+
+  get label() {
+    // Return a label corresponding to this scientific name -- we use the complete verbatim name.
+    return this.scientificName;
+  }
+}
+
+/* Specimen wrapper */
+
+class SpecimenWrapper {
+  // Wraps a specimen identifier.
+
+  constructor(specimen) {
+    // Constructs a wrapper around a specimen.
+    this.specimen = specimen;
+
+    if (!hasOwnProperty(specimen, 'occurrenceID')) {
+      // There might be a catalogNumber, institutionCode or a collectionCode.
+      // In which case, let's construct an occurrenceID!
+      if (hasOwnProperty(specimen, 'catalogNumber')) {
+        if (hasOwnProperty(specimen, 'institutionCode')) {
+          if (hasOwnProperty(specimen, 'collectionCode')) {
+            this.specimen.occurrenceID = `urn:catalog:${specimen.institutionCode}:${specimen.collectionCode}:${specimen.catalogNumber}`;
+          } else {
+            this.specimen.occurrenceID = `urn:catalog:${specimen.institutionCode}::${specimen.catalogNumber}`;
+          }
+        } else {
+          this.specimen.occurrenceID = `urn:catalog:::${specimen.catalogNumber}`;
+        }
+      } else {
+        this.specimen.occurrenceID = 'urn:catalog:::';
+      }
+    }
+  }
+
+  static createFromOccurrenceID(occurrenceID) {
+    // Create a specimen object from the occurrence ID.
+    // The two expected formats are:
+    //  - 'urn:catalog:[institutionCode]:[collectionCode]:[catalogNumber]'
+    //      (in which case, we ignore the first two "components" here)
+    //  - '[institutionCode]:[collectionCode]:[catalogNumber]'
+    // Note that the returned object is NOT wrapped -- so please wrap it if needed!
+
+    // Copy the occurrence ID so we can truncate it if necessary.
+    let occurID = occurrenceID;
+    if (occurID.startsWith('urn:catalog:')) occurID = occurID.substr(12);
+
+    // Prepare the specimen.
+    const specimen = {
+      occurrenceID: occurID,
+    };
+
+    // Look for certain prefixes that suggest that we've been passed a URN or
+    // URL instead. If so, don't do any further processing!
+    const URL_URN_PREFIXES = [
+      'http://',
+      'https://',
+      'ftp://',
+      'sftp://',
+      'file://',
+      'urn:',
+    ];
+    if (URL_URN_PREFIXES.filter(prefix => occurID.toLowerCase().startsWith(prefix)).length > 0) {
+      return specimen;
+    }
+
+    // Parsing an occurrence ID takes some time, so we should memoize it.
+    if (phyxCacheManager.has('SpecimenWrapper.occurrenceIDCache', occurID)) {
+      return phyxCacheManager.get('SpecimenWrapper.occurrenceIDCache', occurID);
+    }
+
+    // Split the occurrence ID into components, and store them in the appropriate fields.
+    const comps = occurID.split(/:/);
+    if (comps.length === 1) {
+      // specimen.institutionCode = undefined;
+      // specimen.collectionCode = undefined;
+      [specimen.catalogNumber] = comps;
+    } else if (comps.length === 2) {
+      [specimen.institutionCode, specimen.catalogNumber] = comps;
+    } else if (comps.length >= 3) {
+      let catalogNumValues = []; // Store all split catalog number values.
+      [specimen.institutionCode, specimen.collectionCode, ...catalogNumValues] = comps;
+      specimen.catalogNumber = catalogNumValues.join(':');
+    }
+
+    phyxCacheManager.put('SpecimenWrapper.occurrenceIDCache', occurID, specimen);
+    return specimen;
+  }
+
+  get catalogNumber() {
+    // Get the catalog number from the specimen object if present.
+    if (hasOwnProperty(this.specimen, 'catalogNumber')) return this.specimen.catalogNumber;
+
+    // Otherwise, try to parse the occurrenceID and see if we can extract a
+    // catalogNumber from there.
+    if (hasOwnProperty(this.specimen, 'occurrenceID')) {
+      const specimen = SpecimenWrapper.createFromOccurrenceID(this.specimen.occurrenceID);
+      if (hasOwnProperty(specimen, 'catalogNumber')) return specimen.catalogNumber;
+    }
+    return undefined;
+  }
+
+  get institutionCode() {
+    // Get the institution code from the specimen object if present.
+    if (hasOwnProperty(this.specimen, 'institutionCode')) return this.specimen.institutionCode;
+
+    // Otherwise, try to parse the occurrenceID and see if we can extract an
+    // occurrenceID from there.
+    if (hasOwnProperty(this.specimen, 'occurrenceID')) {
+      const specimen = SpecimenWrapper.createFromOccurrenceID(this.specimen.occurrenceID);
+      if (hasOwnProperty(specimen, 'institutionCode')) return specimen.institutionCode;
+    }
+    return undefined;
+  }
+
+  get collectionCode() {
+    // Get the collection code from the specimen object if present.
+    if (hasOwnProperty(this.specimen, 'collectionCode')) return this.specimen.collectionCode;
+
+    // Otherwise, try to parse the occurrenceID and see if we can extract an
+    // occurrenceID from there.
+    if (hasOwnProperty(this.specimen, 'occurrenceID')) {
+      const specimen = SpecimenWrapper.createFromOccurrenceID(this.specimen.occurrenceID);
+      if (hasOwnProperty(specimen, 'collectionCode')) return specimen.collectionCode;
+    }
+    return undefined;
+  }
+
+  get occurrenceID() {
+    // Does this specimen have an occurrenceID? If so, return it.
+    // If not, we attempt to construct one in the form:
+    //   "urn:catalog:" + institutionCode (if present) + ':' +
+    //      collectionCode (if present) + ':' + catalogNumber (if present)
+    // If all else fails, we return undefined.
+    //
+    // If this was a full wrapper, we might create a setter on the occurrenceID;
+    // however, the Vue model modifies the underlying specimen object, not the
+    // wrapper.
+
+    // Return the occurrenceID if it exists.
+    if (hasOwnProperty(this.specimen, 'occurrenceID') && this.specimen.occurrenceID.trim() !== '') {
+      return this.specimen.occurrenceID.trim();
+    }
+
+    // Otherwise, we could try to construct the occurrenceID from its components.
+    if (hasOwnProperty(this.specimen, 'catalogNumber')) {
+      if (hasOwnProperty(this.specimen, 'institutionCode')) {
+        if (hasOwnProperty(this.specimen, 'collectionCode')) {
+          return `urn:catalog:${this.specimen.institutionCode.trim()}:${this.specimen.collectionCode.trim()}:${this.specimen.catalogNumber.trim()}`;
+        }
+        return `urn:catalog:${this.specimen.institutionCode.trim()}::${this.specimen.catalogNumber.trim()}`;
+      }
+      if (hasOwnProperty(this.specimen, 'collectionCode')) {
+        return `urn:catalog::${this.specimen.collectionCode.trim()}:${this.specimen.catalogNumber.trim()}`;
+      }
+      return `urn:catalog:::${this.specimen.catalogNumber.trim()}`;
+    }
+
+    // None of our specimen identifier schemes worked.
+    return undefined;
+  }
+
+  get label() {
+    // Return a label for this specimen
+    return `Specimen ${this.occurrenceID}`;
+  }
+}
+
+/* Taxonomic unit wrapper */
+
+class TaxonomicUnitWrapper {
+  // Wraps a taxonomic unit.
+  // Also provides static methods for obtaining lists of wrapped taxonomic units
+  // from node labels.
+
+  constructor(tunit) {
+    // Wrap a taxonomic unit.
+    this.tunit = tunit;
+  }
+
+  get label() {
+    // Try to determine the label of a taxonomic unit. This checks the
+    // 'label' and 'description' properties, and then tries to create a
+    // descriptive label by combining the scientific names, specimens
+    // and external references of the taxonomic unit.
+    const labels = [];
+
+    // A label or description for the TU?
+    if (hasOwnProperty(this.tunit, 'label')) return this.tunit.label;
+    if (hasOwnProperty(this.tunit, 'description')) return this.tunit.description;
+
+    // Any specimens?
+    if (hasOwnProperty(this.tunit, 'includesSpecimens')) {
+      this.tunit.includesSpecimens.forEach((specimen) => {
+        labels.push(new SpecimenWrapper(specimen).label);
+      });
+    }
+
+    // Any external references?
+    if (hasOwnProperty(this.tunit, 'externalReferences')) {
+      this.tunit.externalReferences.forEach(externalRef => labels.push(`<${externalRef}>`));
+    }
+
+    // Any scientific names?
+    if (hasOwnProperty(this.tunit, 'scientificNames')) {
+      this.tunit.scientificNames.forEach((scname) => {
+        labels.push(new ScientificNameWrapper(scname).label);
+      });
+    }
+
+    // If we don't have any properties of a taxonomic unit, return undefined.
+    if (labels.length === 0) return undefined;
+
+    return labels.join(' or ');
+  }
+
+  // Access variables in the underlying wrapped taxonomic unit.
+  get scientificNames() {
+    return this.tunit.scientificNames;
+  }
+
+  get includeSpecimens() {
+    return this.tunit.includesSpecimens;
+  }
+
+  get externalReferences() {
+    return this.tunit.externalReferences;
+  }
+
+  static getTaxonomicUnitsFromNodeLabel(nodeLabel) {
+    // Given a node label, attempt to parse it as a scientific name.
+    // Returns a list of taxonomic units.
+    if (nodeLabel === undefined || nodeLabel === null) return [];
+
+    // This regular expression times a while to run, so let's memoize this.
+    if (phyxCacheManager.has('TaxonomicUnitWrapper.taxonomicUnitsFromNodeLabelCache', nodeLabel)) {
+      return phyxCacheManager.get('TaxonomicUnitWrapper.taxonomicUnitsFromNodeLabelCache', nodeLabel);
+    }
+
+    // Check if the label starts with a binomial name.
+    let tunits = [];
+    const results = /^([A-Z][a-z]+)[ _]([a-z-]+)(?:\b|_)\s*(.*)/.exec(nodeLabel);
+    if (results !== null) {
+      tunits = [{
+        scientificNames: [{
+          scientificName: `${results[1]} ${results[2]} ${results[3]}`.trim(),
+          binomialName: `${results[1]} ${results[2]}`,
+          genus: results[1],
+          specificEpithet: results[2],
+        }],
+      }];
+    } else {
+      // It may be a scientific name, but we don't know how to parse it as such.
+      tunits = [];
+    }
+
+    // Record in the cache
+    phyxCacheManager.put('TaxonomicUnitWrapper.taxonomicUnitsFromNodeLabelCache', nodeLabel, tunits);
+
+    return tunits;
+  }
+}
+
+/* Taxonomic unit matching */
+
+class TaxonomicUnitMatcher {
+  // A taxonomic unit matcher tests for taxonomic matches between pairs of
+  // taxonomic units.
+
+  constructor(tunit1, tunit2) {
+    // Construct a Taxonomic Unit Matcher to compare the two provided
+    // taxonomic units.
+    this.tunit1 = tunit1;
+    this.tunit2 = tunit2;
+
+    // Set up places to store the match results.
+    this.matched = undefined; // Boolean variable for storing whether these TUnits matched.
+    this.matchReason = undefined; // The reason provided for this match.
+
+    // Execute the match.
+    this.match();
+  }
+
+  asJSONLD(idURI) {
+    // Return this TUMatch as a JSON object for insertion into the PHYX file.
+    if (!this.matched) return undefined;
+
+    return {
+      '@id': idURI,
+      '@type': 'testcase:TUMatch',
+      reason: this.matchReason,
+      matchesTaxonomicUnits: [
+        { '@id': this.tunit1['@id'] },
+        { '@id': this.tunit2['@id'] },
+      ],
+    };
+  }
+
+  match() {
+    // Try to match the two taxonomic units using a number of matching methods.
+    if (
+      this.matchByBinomialName() ||
+      this.matchByExternalReferences() ||
+      this.matchBySpecimenIdentifier()
+    ) {
+      this.matched = true;
+    } else {
+      this.matched = false;
+      this.matchReason = undefined;
+    }
+  }
+
+  matchByBinomialName() {
+    // Try to match by binomial name, and return true if it could be matched.
+
+    // Do both TUnits have scientificNames?
+    if (!hasOwnProperty(this.tunit1, 'scientificNames') || !hasOwnProperty(this.tunit2, 'scientificNames')) return false;
+
+    return this.tunit1.scientificNames.some((scname1) => {
+      const scname1wrapped = new ScientificNameWrapper(scname1);
+      return this.tunit2.scientificNames.some((scname2) => {
+        const scname2wrapped = new ScientificNameWrapper(scname2);
+
+        const result = scname1wrapped.binomialName !== undefined &&
+          scname2wrapped.binomialName !== undefined &&
+          scname1wrapped.binomialName.trim().length > 0 &&
+          scname1wrapped.binomialName.trim() === scname2wrapped.binomialName.trim();
+
+        if (result) {
+          this.matchReason = `Scientific name '${scname1wrapped.scientificName}' and scientific name '${scname2wrapped.scientificName}' share the same binomial name`;
+        }
+
+        return result;
+      });
+    });
+  }
+
+  matchByExternalReferences() {
+    // Try to match by external references.
+
+    if (hasOwnProperty(this.tunit1, 'externalReferences') && hasOwnProperty(this.tunit2, 'externalReferences')) {
+      // Each external reference is a URL as a string. We will lowercase it,
+      // but do no other transformation.
+      return this.tunit1.externalReferences.some(extref1 =>
+        this.tunit2.externalReferences.some((extref2) => {
+          const result = (
+            // Make sure that the external reference isn't blank
+            extref1.trim() !== '' &&
+
+            // And that it is identical after trimming
+            extref1.toLowerCase().trim() === extref2.toLowerCase().trim()
+          );
+
+          if (result) {
+            this.matchReason = `External reference '${extref1}' is shared by taxonomic unit ${this.tunit1} and ${this.tunit2}`;
+          }
+
+          return result;
+        }));
+    }
+
+    return false;
+  }
+
+  matchBySpecimenIdentifier() {
+    // Try to match by specimen identifier (i.e. occurrence ID).
+
+    if (hasOwnProperty(this.tunit1, 'includesSpecimens') && hasOwnProperty(this.tunit2, 'includesSpecimens')) {
+      // Convert specimen identifiers (if present) into a standard format and compare those.
+      return this.tunit1.includesSpecimens.some((specimen1) => {
+        const specimenURN1 = new SpecimenWrapper(specimen1).occurrenceID;
+        return this.tunit2.includesSpecimens.some((specimen2) => {
+          const specimenURN2 = new SpecimenWrapper(specimen2).occurrenceID;
+
+          const result = (specimenURN1 === specimenURN2);
+
+          if (result) {
+            this.matchReason = `Specimen identifier '${specimenURN1}' is shared by taxonomic units`;
+          }
+
+          return result;
+        });
+      });
+    }
+
+    return false;
+  }
+}
+
+/* Phylogeny wrapper */
+
+class PhylogenyWrapper {
+  // Wraps a Phylogeny in a PHYX file and provides access to node, node labels
+  // and other information. Remember that a Phylogeny also has the
+  // additionalNodeProperties object which provides additional properties for
+  // nodes.
+
+  constructor(phylogeny) {
+    // Construct a phylogeny based on a Phylogeny object in a PHYX phylogeny.
+    // Note that this version ONLY uses the `newick` property to determine the
+    // phylogeny: if other representations are included (such as a node-based
+    // format, as used in JSON-LD), they will be ignored and possibly overwritten
+    // during export. So, to update the phylogeny, please only update the newick
+    // string!
+    //
+    // This ensures that we don't need to reconcile between different
+    // possible representations of a phylogeny.
+    this.phylogeny = phylogeny;
+  }
+
+  static getErrorsInNewickString(newick) {
+    // Given a Newick string, return a list of errors found in parsing this
+    // string. The errors are returned as a list of objects, each of which
+    // has two properties:
+    //  - title: A short title of the error, distinct for each type of error.
+    //  - message: A longer description of the error, which might include
+    //    information specific to a particular error.
+    //
+    // We try to order errors from most helpful ('Unbalanced parentheses in
+    // Newick string') to least helpful ('Error parsing phylogeny').
+    const newickTrimmed = newick.trim();
+    const errors = [];
+
+    // Look for an empty Newick string.
+    if (newickTrimmed === '' || newickTrimmed === '()' || newickTrimmed === '();') {
+      // None of the later errors are relevant here, so bail out now.
+      return [{
+        title: 'No phylogeny entered',
+        message: 'Click on "Edit as Newick" to enter a phylogeny below.',
+      }];
+    }
+
+    // Look for an unbalanced Newick string.
+    let parenLevels = 0;
+    for (let x = 0; x < newickTrimmed.length; x += 1) {
+      if (newickTrimmed[x] === '(') parenLevels += 1;
+      if (newickTrimmed[x] === ')') parenLevels -= 1;
+    }
+
+    if (parenLevels !== 0) {
+      errors.push({
+        title: 'Unbalanced parentheses in Newick string',
+        message: (parenLevels > 0 ?
+          `You have ${parenLevels} too many open parentheses` :
+          `You have ${-parenLevels} too few open parentheses`
+        ),
+      });
+    }
+
+    // Finally, try parsing it with newick_parser and see if we get an error.
+    const parsed = d3.layout.newick_parser(newickTrimmed);
+    if (!hasOwnProperty(parsed, 'json') || parsed.json === null) {
+      const error = (hasOwnProperty(parsed, 'error') ? parsed.error : 'unknown error');
+      errors.push({
+        title: 'Error parsing phylogeny',
+        message: `An error occured while parsing this phylogeny: ${error}`,
+      });
+    }
+
+    return errors;
+  }
+
+  static recurseNodes(node, func, nodeCount = 0, parentCount = undefined) {
+    // Recurse through PhyloTree nodes, executing function on each node.
+    //  - node: The node to recurse from. The function will be called on node
+    //          *before* being called on its children.
+    //  - func: The function to call on `node` and all of its children.
+    //  - nodeCount: `node` will be called with this nodeCount. All of its
+    //          children will be called with consecutively increasing nodeCounts.
+    //  - parentCount: The nodeCount associated with the parent of this node
+    //          within this run of recurseNodes. For instance, immediate children
+    //          of `node` will have a parentCount of 0. By default, `node` itself
+    //          will have a parentCount of `undefined`.
+    // When the function `func` is called, it is given three arguments:
+    //  - The current node object (initially: `node`)
+    //  - The count of the current node object (initially: `nodeCount`)
+    //  - The parent count of the current node object (initially: `parentCount`)
+    func(node, nodeCount, parentCount);
+
+    let nextID = nodeCount + 1;
+
+    // Recurse through all children of this node.
+    if (hasOwnProperty(node, 'children')) {
+      node.children.forEach((child) => {
+        nextID = PhylogenyWrapper.recurseNodes(
+          child,
+          func,
+          nextID,
+          nodeCount,
+        );
+      });
+    }
+
+    return nextID;
+  }
+
+  getTaxonomicUnits(nodeType = 'both') {
+    // Return a list of all taxonomic units in this phylogeny.
+    // Node labels will be extracted from:
+    //  - internal nodes only (if nodeType == 'internal')
+    //  - terminal nodes only (if nodeType == 'terminal')
+    //  - both internal and terminal nodes (if nodeType == 'both')
+    //
+    // See `getTaxonomicUnitsForNodeLabel` to see how node labels are converted
+    // into node labels, but in brief:
+    //  1. We look for taxonomic units in the additionalNodeProperties.
+    //  2. If none are found, we attempt to parse the node label as a scientific name.
+    //
+    const nodeLabels = this.getNodeLabels(nodeType);
+    const tunits = new Set();
+
+    nodeLabels.forEach(nodeLabel =>
+      this.getTaxonomicUnitsForNodeLabel(nodeLabel).forEach(tunit => tunits.add(tunit)));
+
+    return tunits;
+  }
+
+  getNodeLabels(nodeType = 'both') {
+    // Return a list of all the node labels in a phylogeny.
+    //
+    // nodeType can be one of:
+    // - 'internal': Return node labels on internal nodes.
+    // - 'terminal': Return node labels on terminal nodes.
+    // - 'both': Return node labels on both internal and terminal nodes.
+
+    const nodeLabels = new Set();
+
+    // Names from the Newick string.
+    const newick = this.phylogeny.newick || '()';
+
+    // Parse the Newick string; if parseable, recurse through the node labels,
+    // adding them all to 'nodeLabels'.
+    const parsed = d3.layout.newick_parser(newick);
+    if (hasOwnProperty(parsed, 'json') && parsed.json !== null) {
+      // Recurse away!
+      PhylogenyWrapper.recurseNodes(parsed.json, (node) => {
+        if (hasOwnProperty(node, 'name') && node.name !== '') {
+          const nodeHasChildren = hasOwnProperty(node, 'children') && node.children.length > 0;
+
+          // Only add the node label if it is on the type of node
+          // we're interested in.
+          if (
+            (nodeType === 'both') ||
+            (nodeType === 'internal' && nodeHasChildren) ||
+            (nodeType === 'terminal' && !nodeHasChildren)
+          ) {
+            nodeLabels.add(node.name);
+          }
+        }
+      });
+    }
+
+    return Array.from(nodeLabels);
+  }
+
+  getTaxonomicUnitsForNodeLabel(nodeLabel) {
+    // Return a list of taxonomic units for a node label.
+
+    // Look up additional node properties.
+    let additionalNodeProperties = {};
+    if (
+      hasOwnProperty(this.phylogeny, 'additionalNodeProperties') &&
+      hasOwnProperty(this.phylogeny.additionalNodeProperties, nodeLabel)
+    ) {
+      additionalNodeProperties = this.phylogeny.additionalNodeProperties[nodeLabel];
+    }
+
+    // If there are explicit taxonomic units in the
+    // representsTaxonomicUnits property, we need to use those.
+    if (hasOwnProperty(additionalNodeProperties, 'representsTaxonomicUnits')) {
+      return additionalNodeProperties.representsTaxonomicUnits;
+    }
+
+    // If that doesn't work, we can try to extract scientific names from
+    // the node label. Note that taxonomic units will NOT be extracted from
+    // the label if there is a taxonomic unit present!
+    return TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel(nodeLabel.trim());
+  }
+
+  getNodeLabelsMatchedBySpecifier(specifier) {
+    // Return a list of node labels matched by a given specifier on
+    // a given phylogeny.
+
+    // Does the specifier have any taxonomic units? If not, we can't
+    // match anything!
+    if (!hasOwnProperty(specifier, 'referencesTaxonomicUnits')) { return []; }
+    const specifierTUnits = specifier.referencesTaxonomicUnits;
+
+    return this.getNodeLabels().filter((nodeLabel) => {
+      // Find all the taxonomic units associated with the specifier and
+      // with the node.
+      const nodeTUnits = this.getTaxonomicUnitsForNodeLabel(nodeLabel);
+
+      // Attempt pairwise matches between taxonomic units in the specifier
+      // and associated with the node.
+      return specifierTUnits.some(tunit1 =>
+        nodeTUnits.some(tunit2 => new TaxonomicUnitMatcher(tunit1, tunit2).matched));
+    });
+  }
+
+  getParsedNewickWithIRIs(baseURI) {
+    // Return the parsed Newick string, but with EVERY node given an IRI.
+    // baseURI: The base URI to use for node elements (e.g. ':phylogeny1').
+
+    const newick = this.phylogeny.newick || '()';
+    const parsed = d3.layout.newick_parser(newick);
+    if (hasOwnProperty(parsed, 'json')) {
+      PhylogenyWrapper.recurseNodes(parsed.json, (node, nodeCount) => {
+        // Start with the additional node properties.
+        const nodeAsJSONLD = node;
+
+        // Set @id and @type.
+        const nodeURI = `${baseURI}_node${nodeCount}`;
+        nodeAsJSONLD['@id'] = nodeURI;
+      });
+    }
+
+    return parsed;
+  }
+
+  getNodesAsJSONLD(baseURI) {
+    // Returns a list of all nodes in this phylogeny as a series of nodes.
+    // - baseURI: The base URI to use for node elements (e.g. ':phylogeny1').
+
+    // List of nodes we have identified.
+    const nodes = [];
+
+    // We need to track the identifiers we give each node as we go.
+    const nodesById = {};
+    const nodeIdsByParentId = {};
+
+    // Extract the newick string.
+    const { additionalNodeProperties } = this.phylogeny;
+
+    // Parse the Newick string; if parseable, recurse through the nodes,
+    // added them to the list of JSON-LD nodes as we go.
+
+    const parsed = this.getParsedNewickWithIRIs(baseURI);
+    if (hasOwnProperty(parsed, 'json')) {
+      PhylogenyWrapper.recurseNodes(parsed.json, (node, nodeCount, parentCount) => {
+        // Start with the additional node properties.
+        const nodeAsJSONLD = {};
+
+        // Set @id and @type. '@id' should already be set by getParsedNewickWithIRIs()!
+        const nodeURI = node['@id'];
+        nodeAsJSONLD['@id'] = nodeURI;
+        nodeAsJSONLD['@type'] = 'http://purl.obolibrary.org/obo/CDAO_0000140';
+
+        // Add labels, additional node properties and taxonomic units.
+        if (hasOwnProperty(node, 'name') && node.name !== '') {
+          // Add node label.
+          nodeAsJSONLD.labels = [node.name];
+
+          // Add additional node properties, if any.
+          if (additionalNodeProperties && hasOwnProperty(additionalNodeProperties, node.name)) {
+            Object.keys(additionalNodeProperties[node.name]).forEach((key) => {
+              nodeAsJSONLD[key] = additionalNodeProperties[node.name][key];
+            });
+          }
+
+          // Add taxonomic units.
+          nodeAsJSONLD.representsTaxonomicUnits = this.getTaxonomicUnitsForNodeLabel(node.name);
+
+          // Apply @id and @type to each taxonomic unit.
+          let countTaxonomicUnits = 0;
+          nodeAsJSONLD.representsTaxonomicUnits.forEach((tunitToChange) => {
+            const tunit = tunitToChange;
+
+            tunit['@id'] = `${nodeURI}_taxonomicunit${countTaxonomicUnits}`;
+            tunit['@type'] = 'http://purl.obolibrary.org/obo/CDAO_0000138';
+            countTaxonomicUnits += 1;
+          });
+        }
+
+        // Add references to parents and siblings.
+        if (parentCount !== undefined) {
+          const parentURI = `${baseURI}_node${parentCount}`;
+          nodeAsJSONLD.parent = parentURI;
+
+          // Update list of nodes by parent IDs.
+          if (!hasOwnProperty(nodeIdsByParentId, parentURI)) {
+            nodeIdsByParentId[parentURI] = new Set();
+          }
+          nodeIdsByParentId[parentURI].add(nodeURI);
+        }
+
+        // Add nodeAsJSONLD to list
+        if (hasOwnProperty(nodesById, nodeURI)) {
+          throw new Error('Error in programming: duplicate node URI generated');
+        }
+        nodesById[nodeURI] = nodeAsJSONLD;
+        nodes.push(nodeAsJSONLD);
+      });
+    }
+
+    // Go through nodes again and set children and sibling relationships.
+    Object.keys(nodeIdsByParentId).forEach((parentId) => {
+      // What are the children of this parentId?
+      const childrenIDs = Array.from(nodeIdsByParentId[parentId]);
+      const children = childrenIDs.map(childId => nodesById[childId]);
+
+      // Is this the root node?
+      if (hasOwnProperty(nodesById, parentId)) {
+        const parent = nodesById[parentId];
+        parent.children = childrenIDs;
+      }
+
+      children.forEach((child) => {
+        const childToModify = child;
+        // Add all other sibling to node.siblings, but don't add this node itself!
+        childToModify.siblings = childrenIDs.filter(childId => childId !== child['@id']);
+      });
+    });
+
+    return nodes;
+  }
+
+  asJSONLD(baseURI) {
+    // Export this phylogeny as JSON-LD.
+
+    // Create a copy to export.
+    const phylogenyAsJSONLD = JSON.parse(JSON.stringify(this.phylogeny));
+
+    // Set name and class for phylogeny.
+    phylogenyAsJSONLD['@id'] = baseURI;
+    phylogenyAsJSONLD['@type'] = PHYLOREFERENCE_PHYLOGENY;
+
+    // Translate nodes into JSON-LD objects.
+    phylogenyAsJSONLD.nodes = this.getNodesAsJSONLD(baseURI);
+    if (phylogenyAsJSONLD.nodes.length > 0) {
+      // We don't have a better way to identify the root node, so we just
+      // default to the first one.
+      phylogenyAsJSONLD.hasRootNode = {
+        '@id': phylogenyAsJSONLD.nodes[0]['@id'],
+      };
+    }
+
+    return phylogenyAsJSONLD;
+  }
+}
+
+/* Phyloreference wrapper */
+
+// eslint-disable-next-line no-unused-vars
+class PhylorefWrapper {
+  // Wraps a phyloreference in a PHYX model.
+
+  constructor(phyloref) {
+    // Wraps the provided phyloreference
+    this.phyloref = phyloref;
+
+    // Reset internal and external specifiers if needed.
+    // if (!hasOwnProperty(this.phyloref, 'internalSpecifiers')) Vue.set(this.phyloref, 'internalSpecifiers', []);
+    if (!hasOwnProperty(this.phyloref, 'internalSpecifiers')) {
+        this.phyloref.internalSpecifiers = [];
+    }
+    // if (!hasOwnProperty(this.phyloref, 'externalSpecifiers')) Vue.set(this.phyloref, 'externalSpecifiers', []);
+    if (!hasOwnProperty(this.phyloref, 'externalSpecifiers')) {
+        this.phyloref.externalSpecifiers = [];
+    }
+  }
+
+  get label() {
+    // Return a label for this phyloreference.
+    if (hasOwnProperty(this.phyloref, 'label')) return this.phyloref.label;
+    if (hasOwnProperty(this.phyloref, 'labels') && this.phyloref.labels.length > 0) return this.phyloref.labels[0];
+    if (hasOwnProperty(this.phyloref, 'title')) return this.phyloref.title;
+
+    return undefined;
+  }
+
+  set label(newLabel) {
+    // Set a label for this phyloreference.
+    if (hasOwnProperty(this.phyloref, 'label')) {
+      this.phyloref.label = newLabel;
+    } else {
+      // Vue.set(this.phyloref, 'label', newLabel);
+      this.phyloref.label = newLabel;
+    }
+  }
+
+  get specifiers() {
+    // Returns a list of all specifiers by combining the internal and external
+    // specifiers into a single list, with internal specifiers before
+    // external specifiers.
+    let specifiers = this.phyloref.internalSpecifiers;
+    specifiers = specifiers.concat(this.phyloref.externalSpecifiers);
+    return specifiers;
+  }
+
+  getSpecifierType(specifier) {
+    // For a given specifier, return a string indicating whether it is
+    // an 'Internal' or 'External' specifier.
+
+    if (this.phyloref.internalSpecifiers.includes(specifier)) return 'Internal';
+    if (this.phyloref.externalSpecifiers.includes(specifier)) return 'External';
+    return 'Specifier';
+  }
+
+  setSpecifierType(specifier, specifierType) {
+    // Change the type of a given specifier. To do this, we first need
+    // to determine if it was originally an internal or external
+    // specifier, then move it into the other list.
+
+    let index;
+    if (specifierType === 'Internal') {
+      // To set a specifier to 'Internal', we might need to delete it from the
+      // list of external specifiers first.
+      index = this.phyloref.externalSpecifiers.indexOf(specifier);
+      if (index !== -1) this.phyloref.externalSpecifiers.splice(index, 1);
+
+      // Don't add it to the list of internal specifiers if it's already there.
+      if (!this.phyloref.internalSpecifiers.includes(specifier)) {
+        this.phyloref.internalSpecifiers.unshift(specifier);
+      }
+    } else if (specifierType === 'External') {
+      // To set a specifier to 'External', we might need to delete it from the
+      // list of internal specifiers first.
+      index = this.phyloref.internalSpecifiers.indexOf(specifier);
+      if (index !== -1) this.phyloref.internalSpecifiers.splice(index, 1);
+
+      // Don't add it to the list of internal specifiers if it's already there.
+      if (!this.phyloref.externalSpecifiers.includes(specifier)) {
+        this.phyloref.externalSpecifiers.unshift(specifier);
+      }
+    } else {
+      // Neither internal nor external? Ignore.
+    }
+  }
+
+  deleteSpecifier(specifier) {
+    // Since the user interface combines specifiers into a single list,
+    // it doesn't remember if the specifier to be deleted is internal
+    // or external. We delete the intended specifier from both arrays.
+
+    let index = this.phyloref.internalSpecifiers.indexOf(specifier);
+    if (index !== -1) this.phyloref.internalSpecifiers.splice(index, 1);
+
+    index = this.phyloref.externalSpecifiers.indexOf(specifier);
+    if (index !== -1) this.phyloref.externalSpecifiers.splice(index, 1);
+  }
+
+  static getSpecifierLabel(specifier) {
+    // Try to determine the label of a specifier. This checks the
+    // 'label' and 'description' properties, and then tries to create a
+    // descriptive label by using the list of referenced taxonomic units.
+    //
+    // This logically belongs in PhylorefWrapper, but we don't actually need to
+    // know the phyloreference to figure out the specifier label, which is why
+    // this is a static method.
+
+    // Is this specifier even non-null?
+    if (specifier === undefined) return undefined;
+    if (specifier === null) return undefined;
+
+    // Maybe there is a label or description right there?
+    if (hasOwnProperty(specifier, 'label')) return specifier.label;
+    if (hasOwnProperty(specifier, 'description')) return specifier.description;
+
+    // Look at the individual taxonomic units.
+    if (hasOwnProperty(specifier, 'referencesTaxonomicUnits')) {
+      const labels = specifier.referencesTaxonomicUnits
+        .map(tu => new TaxonomicUnitWrapper(tu).label)
+        .filter(label => (label !== undefined));
+      if (labels.length > 0) return labels.join('; ');
+    }
+
+    // No idea!
+    return undefined;
+  }
+
+  getExpectedNodeLabels(phylogeny) {
+    // Given a phylogeny, determine which node labels we expect this phyloref to
+    // resolve to. To do this, we:
+    //  1. Find all node labels that are case-sensitively identical
+    //     to the phyloreference.
+    //  2. Find all node labels that have additionalNodeProperties with
+    //     expectedPhyloreferenceNamed case-sensitively identical to
+    //     the phyloreference.
+    const phylorefLabel = this.label;
+    const nodeLabels = new Set();
+
+    new PhylogenyWrapper(phylogeny).getNodeLabels().forEach((nodeLabel) => {
+      // Is this node label identical to the phyloreference name?
+      if (nodeLabel === phylorefLabel) {
+        nodeLabels.add(nodeLabel);
+      } else if (
+        hasOwnProperty(phylogeny, 'additionalNodeProperties') &&
+        hasOwnProperty(phylogeny.additionalNodeProperties, nodeLabel) &&
+        hasOwnProperty(phylogeny.additionalNodeProperties[nodeLabel], 'expectedPhyloreferenceNamed')
+      ) {
+        // Does this node label have an expectedPhyloreferenceNamed that
+        // includes this phyloreference name?
+
+        const expectedPhylorefs = phylogeny
+          .additionalNodeProperties[nodeLabel]
+          .expectedPhyloreferenceNamed;
+
+        if (expectedPhylorefs.includes(phylorefLabel)) {
+          nodeLabels.add(nodeLabel);
+        }
+      }
+    });
+
+    // Return node labels sorted alphabetically.
+    return Array.from(nodeLabels).sort();
+  }
+
+  static getStatusCURIEsInEnglish() {
+    // Return dictionary of all phyloref statuses in English
+    return {
+      'pso:draft': 'Draft',
+      'pso:final-draft': 'Final draft',
+      'pso:under-review': 'Under review',
+      'pso:submitted': 'Tested',
+      'pso:published': 'Published',
+      'pso:retracted-from-publication': 'Retracted',
+    };
+  }
+
+  getCurrentStatus() {
+    // Return a result object that contains:
+    //  - status: phyloreference status as a short URI (CURIE)
+    //  - statusInEnglish: an English representation of the phyloref status
+    //  - intervalStart: the start of the interval
+    //  - intervalEnd: the end of the interval
+
+    if (
+      hasOwnProperty(this.phyloref, 'pso:holdsStatusInTime') &&
+      Array.isArray(this.phyloref['pso:holdsStatusInTime']) &&
+      this.phyloref['pso:holdsStatusInTime'].length > 0
+    ) {
+      // If we have any pso:holdsStatusInTime entries, pick the first one and
+      // extract the CURIE and time interval information from it.
+      const lastStatusInTime = this.phyloref['pso:holdsStatusInTime'][this.phyloref['pso:holdsStatusInTime'].length - 1];
+      const statusCURIE = lastStatusInTime['pso:withStatus']['@id'];
+
+      // Look for time interval information
+      let intervalStart;
+      let intervalEnd;
+
+      if (hasOwnProperty(lastStatusInTime, 'tvc:atTime')) {
+        const atTime = lastStatusInTime['tvc:atTime'];
+        if (hasOwnProperty(atTime, 'timeinterval:hasIntervalStartDate')) intervalStart = atTime['timeinterval:hasIntervalStartDate'];
+        if (hasOwnProperty(atTime, 'timeinterval:hasIntervalEndDate')) intervalEnd = atTime['timeinterval:hasIntervalEndDate'];
+      }
+
+      // Return result object
+      return {
+        statusCURIE,
+        statusInEnglish: PhylorefWrapper.getStatusCURIEsInEnglish()[statusCURIE],
+        intervalStart,
+        intervalEnd,
+      };
+    }
+
+    // If we couldn't figure out a status for this phyloref, assume it's a draft.
+    return {
+      statusCURIE: 'pso:draft',
+      statusInEnglish: PhylorefWrapper.getStatusCURIEsInEnglish()['pso:draft'],
+    };
+  }
+
+  getStatusChanges() {
+    // Return a list of status changes for a particular phyloreference
+    if (hasOwnProperty(this.phyloref, 'pso:holdsStatusInTime')) {
+      return this.phyloref['pso:holdsStatusInTime'].map((entry) => {
+        const result = {};
+
+        // Create a statusCURIE convenience field.
+        if (hasOwnProperty(entry, 'pso:withStatus')) {
+          result.statusCURIE = entry['pso:withStatus']['@id'];
+          result.statusInEnglish = PhylorefWrapper.getStatusCURIEsInEnglish()[result.statusCURIE];
+        }
+
+        // Create intervalStart/intervalEnd convenient fields
+        if (hasOwnProperty(entry, 'tvc:atTime')) {
+          const atTime = entry['tvc:atTime'];
+          if (hasOwnProperty(atTime, 'timeinterval:hasIntervalStartDate')) {
+            result.intervalStart = atTime['timeinterval:hasIntervalStartDate'];
+            result.intervalStartAsCalendar = moment(result.intervalStart).calendar();
+          }
+
+          if (hasOwnProperty(atTime, 'timeinterval:hasIntervalEndDate')) {
+            result.intervalEnd = atTime['timeinterval:hasIntervalEndDate'];
+            result.intervalEndAsCalendar = moment(result.intervalEnd).calendar();
+          }
+        }
+
+        return result;
+      });
+    }
+
+    // No changes? Return an empty list.
+    return [];
+  }
+
+  setStatus(status) {
+    // Set the status of a phyloreference
+    //
+    // Check whether we have a valid status CURIE.
+    if (!hasOwnProperty(PhylorefWrapper.getStatusCURIEsInEnglish(), status)) {
+      throw new TypeError(`setStatus() called with invalid status CURIE '${status}'`);
+    }
+
+    // See if we can end the previous interval.
+    const currentTime = new Date(Date.now()).toISOString();
+
+    if (!hasOwnProperty(this.phyloref, 'pso:holdsStatusInTime')) {
+      // Vue.set(this.phyloref, 'pso:holdsStatusInTime', []);
+      this.phyloref['pso:holdsStatusInTime'] = [];
+    }
+
+    // Check to see if there's a previous time interval we should end.
+    if (
+      Array.isArray(this.phyloref['pso:holdsStatusInTime']) &&
+      this.phyloref['pso:holdsStatusInTime'].length > 0
+    ) {
+      const lastStatusInTime = this.phyloref['pso:holdsStatusInTime'][this.phyloref['pso:holdsStatusInTime'].length - 1];
+
+      // if (!hasOwnProperty(lastStatusInTime, 'tvc:atTime')) Vue.set(lastStatusInTime, 'tvc:atTime', {});
+      if (!hasOwnProperty(lastStatusInTime, 'tvc:atTime')) {
+          lastStatusInTime['tvc:atTime'] = {};
+      }
+      if (!hasOwnProperty(lastStatusInTime['tvc:atTime'], 'timeinterval:hasIntervalEndDate')) {
+        // If the last time entry doesn't already have an interval end date, set it to now.
+        lastStatusInTime['tvc:atTime']['timeinterval:hasIntervalEndDate'] = currentTime;
+      }
+    }
+
+    // Create new entry.
+    this.phyloref['pso:holdsStatusInTime'].push({
+      '@type': 'http://purl.org/spar/pso/StatusInTime',
+      'pso:withStatus': { '@id': status },
+      'tvc:atTime': {
+        'timeinterval:hasIntervalStartDate': currentTime,
+      },
+    });
+  }
+
+  asJSONLD(phylorefURI) {
+    // Export this phyloreference in JSON-LD.
+
+    // Keep all currently extant data.
+    // - baseURI: the base URI for this phyloreference
+    const phylorefAsJSONLD = JSON.parse(JSON.stringify(this.phyloref));
+
+    // Set the @id and @type.
+    phylorefAsJSONLD['@id'] = phylorefURI;
+
+    phylorefAsJSONLD['@type'] = [
+      // We pun this as an instance that is a Phyloreference.
+      // (We need this to ensure that the object properties that store
+      // information on specifiers will work correctly)
+      'phyloref:Phyloreference',
+      // Since we're writing this in RDF, just adding a '@type' of
+      // phyloref:Phyloreference would imply that phylorefURI is a named
+      // individual of class phyloref:Phyloreference. We need to explicitly
+      // let OWL know that this phylorefURI is an owl:Class.
+      //
+      // (This is implied by some of the properties that we apply to phylorefURI,
+      // such as by the domain of owl:equivalentClass. But it's nice to make that
+      // explicit as well!)
+      'owl:Class',
+    ];
+
+    // Add identifiers for each internal specifier.
+    let internalSpecifierCount = 0;
+    phylorefAsJSONLD.internalSpecifiers.forEach((internalSpecifierToChange) => {
+      internalSpecifierCount += 1;
+
+      const internalSpecifier = internalSpecifierToChange;
+      const specifierId = `${phylorefURI}_specifier_internal${internalSpecifierCount}`;
+
+      internalSpecifier['@id'] = specifierId;
+      internalSpecifier['@type'] = [
+        TESTCASE_SPECIFIER,
+      ];
+
+      // Add identifiers to all taxonomic units.
+      let countTaxonomicUnits = 0;
+      if (hasOwnProperty(internalSpecifier, 'referencesTaxonomicUnits')) {
+        internalSpecifier.referencesTaxonomicUnits.forEach((tunitToChange) => {
+          const tunit = tunitToChange;
+
+          tunit['@id'] = `${specifierId}_tunit${countTaxonomicUnits}`;
+          tunit['@type'] = 'http://purl.obolibrary.org/obo/CDAO_0000138';
+          countTaxonomicUnits += 1;
+        });
+      }
+    });
+
+    // Add identifiers for each external specifier.
+    let externalSpecifierCount = 0;
+    phylorefAsJSONLD.externalSpecifiers.forEach((externalSpecifierToChange) => {
+      externalSpecifierCount += 1;
+
+      const externalSpecifier = externalSpecifierToChange;
+      const specifierId = `${phylorefURI}_specifier_external${externalSpecifierCount}`;
+
+      externalSpecifier['@id'] = specifierId;
+      externalSpecifier['@type'] = [
+        TESTCASE_SPECIFIER,
+      ];
+
+      // Add identifiers to all taxonomic units.
+      let countTaxonomicUnits = 0;
+      if (hasOwnProperty(externalSpecifier, 'referencesTaxonomicUnits')) {
+        externalSpecifier.referencesTaxonomicUnits.forEach((tunitToChange) => {
+          const tunit = tunitToChange;
+
+          tunit['@id'] = `${specifierId}_tunit${countTaxonomicUnits}`;
+          tunit['@type'] = 'http://purl.obolibrary.org/obo/CDAO_0000138';
+          countTaxonomicUnits += 1;
+        });
+      }
+    });
+
+    // For historical reasons, the Clade Ontology uses 'hasInternalSpecifier' to
+    // store the specifiers as OWL classes and 'internalSpecifiers' to store them
+    // as RDF annotations. We simplify that here by duplicating them here, but
+    // this should really be fixed in the Clade Ontology and in phyx.json.
+    phylorefAsJSONLD.hasInternalSpecifier = phylorefAsJSONLD.internalSpecifiers;
+    phylorefAsJSONLD.hasExternalSpecifier = phylorefAsJSONLD.externalSpecifiers;
+
+    if (internalSpecifierCount === 0 && externalSpecifierCount === 0) {
+      phylorefAsJSONLD.malformedPhyloreference = 'No specifiers provided';
+    } else if (externalSpecifierCount > 1) {
+      phylorefAsJSONLD.malformedPhyloreference = 'Multiple external specifiers are not yet supported';
+    } else if (internalSpecifierCount === 1 && externalSpecifierCount === 0) {
+      phylorefAsJSONLD.malformedPhyloreference = 'Only a single internal specifier was provided';
+    } else if (externalSpecifierCount === 0) {
+      // This phyloreference is made up entirely of internal specifiers.
+
+      // We can write this in an accumulative manner by creating class expressions
+      // in the form:
+      //  mrca(mrca(mrca(node1, node2), node3), node4)
+
+      // We could write this as a single giant expression, but this tends to
+      // slow down the reasoner dramatically. So instead, we break it up into a
+      // series of "additional classes", each of which represents a part of the
+      // overall expression.
+      phylorefAsJSONLD.hasAdditionalClass = [];
+
+      let equivalentClassAccumulator = PhylorefWrapper.getClassExpressionForMRCA(
+        phylorefURI,
+        phylorefAsJSONLD.hasAdditionalClass,
+        phylorefAsJSONLD.internalSpecifiers[0],
+        phylorefAsJSONLD.internalSpecifiers[1],
+      );
+
+      for (let index = 2; index < internalSpecifierCount; index += 1) {
+        equivalentClassAccumulator = PhylorefWrapper.getClassExpressionForMRCA(
+          phylorefURI,
+          phylorefAsJSONLD.hasAdditionalClass,
+          equivalentClassAccumulator,
+          phylorefAsJSONLD.internalSpecifiers[index],
+        );
+      }
+
+      phylorefAsJSONLD.equivalentClass = equivalentClassAccumulator;
+    } else {
+      // This phyloreference is made up of one external specifier and some number
+      // of internal specifiers.
+
+      const internalSpecifierRestrictions = phylorefAsJSONLD.internalSpecifiers
+        .map(specifier => PhylorefWrapper
+          .wrapInternalOWLRestriction(PhylorefWrapper.getOWLRestrictionForSpecifier(specifier)));
+
+      const externalSpecifierRestrictions = phylorefAsJSONLD.externalSpecifiers
+        .map(specifier => PhylorefWrapper
+          .wrapExternalOWLRestriction(PhylorefWrapper.getOWLRestrictionForSpecifier(specifier)));
+
+      phylorefAsJSONLD.equivalentClass = {
+        '@type': 'owl:Class',
+        intersectionOf: internalSpecifierRestrictions.concat(externalSpecifierRestrictions),
+      };
+    }
+
+    return phylorefAsJSONLD;
+  }
+
+  static getOWLRestrictionForSpecifier(specifier) {
+    // Return an OWL restriction corresponding to a specifier.
+    return {
+      '@type': 'owl:Restriction',
+      onProperty: 'testcase:matches_specifier',
+      hasValue: {
+        '@id': specifier['@id'],
+      },
+    };
+  }
+
+  static wrapInternalOWLRestriction(restriction) {
+    // Wraps a restriction to act as an internal specifier.
+    // Mainly, we just need to extend the restriction to match:
+    //  restriction or cdao:has_Descendant some restriction
+    return {
+      '@type': 'owl:Restriction',
+      unionOf: [
+        restriction,
+        {
+          '@type': 'owl:Restriction',
+          onProperty: CDAO_HAS_DESCENDANT,
+          someValuesFrom: restriction,
+        },
+      ],
+    };
+  }
+
+  static wrapExternalOWLRestriction(restriction) {
+    // Wraps a restriction to act as an external specifier.
+    // This needs to match:
+    //  cdao:has_Sibling some (restriction or cdao:has_Descendant some restriction)
+    // Since that second part is just an internal specifier restriction, we can
+    // incorporate that in here.
+    return {
+      '@type': 'owl:Restriction',
+      // onProperty: PHYLOREF_HAS_SIBLING,
+      onProperty: PHYLOREF_EXCLUDES_LINEAGE_TO,
+      someValuesFrom: restriction,
+    };
+  }
+
+  static getClassExpressionForMRCA(baseURI, additionalClasses, specifier1, specifier2) {
+    // Create an OWL restriction for the most recent common ancestor (MRCA)
+    // of the nodes matched by two specifiers.
+    const additionalClassesIds = new Set(additionalClasses.map(cl => cl['@id']));
+
+    // Specifiers might be either a real specifier or an additional class.
+    // We can check their @ids here and translate specifiers into class expressions.
+    let owlRestriction1;
+    if (additionalClassesIds.has(specifier1['@id'])) {
+      owlRestriction1 = specifier1;
+    } else {
+      owlRestriction1 = PhylorefWrapper.getOWLRestrictionForSpecifier(specifier1);
+    }
+
+    let owlRestriction2;
+    if (additionalClassesIds.has(specifier2['@id'])) {
+      owlRestriction2 = specifier2;
+    } else {
+      owlRestriction2 = PhylorefWrapper.getOWLRestrictionForSpecifier(specifier2);
+    }
+
+    // Construct OWL expression.
+    const mrcaAsOWL = {
+      '@type': 'owl:Class',
+      unionOf: [
+        {
+          // What if specifier2 is a descendant of specifier1? If so, the MRCA
+          // is specifier1!
+          '@type': 'owl:Class',
+          intersectionOf: [
+            owlRestriction1,
+            {
+              '@type': 'owl:Restriction',
+              onProperty: CDAO_HAS_DESCENDANT,
+              someValuesFrom: owlRestriction2,
+            },
+          ],
+        },
+        {
+          // What if specifier1 is a descendant of specifier2? If so, the MRCA
+          // is specifier2!
+          '@type': 'owl:Class',
+          intersectionOf: [
+            owlRestriction2,
+            {
+              '@type': 'owl:Restriction',
+              onProperty: CDAO_HAS_DESCENDANT,
+              someValuesFrom: owlRestriction1,
+            },
+          ],
+        },
+        {
+          // If neither specifier is a descendant of the other, we can use our
+          // standard formula.
+          '@type': 'owl:Class',
+          intersectionOf: [{
+            '@type': 'owl:Restriction',
+            onProperty: CDAO_HAS_CHILD,
+            someValuesFrom: {
+              '@type': 'owl:Class',
+              intersectionOf: [
+                PhylorefWrapper.wrapInternalOWLRestriction(owlRestriction1),
+                PhylorefWrapper.wrapExternalOWLRestriction(owlRestriction2),
+              ],
+            },
+          }, {
+            '@type': 'owl:Restriction',
+            onProperty: CDAO_HAS_CHILD,
+            someValuesFrom: {
+              '@type': 'owl:Class',
+              intersectionOf: [
+                PhylorefWrapper.wrapInternalOWLRestriction(owlRestriction2),
+                PhylorefWrapper.wrapExternalOWLRestriction(owlRestriction1),
+              ],
+            },
+          }],
+        },
+      ],
+    };
+
+    // Instead of building a single, large, complex expression, reasoners appear
+    // to prefer smaller expressions for classes that are assembled together.
+    // To help with that, we'll store the class expression in the additionalClasses
+    // list, and return a reference to this class.
+    const additionalClassId = `${baseURI}_additional${additionalClasses.length}`;
+    additionalClasses.push({
+      '@id': additionalClassId,
+      '@type': 'owl:Class',
+      equivalentClass: mrcaAsOWL,
+    });
+
+    return { '@id': additionalClassId };
+  }
+}
+
+/* PHYX file wrapper */
+
+// eslint-disable-next-line no-unused-vars
+class PHYXWrapper {
+  // Wraps an entire PHYX document.
+
+  constructor(phyx) {
+    // Wraps an entire PHYX document.
+    this.phyx = phyx;
+  }
+
+  static get BASE_URI() {
+    // Returns the default base URI for PHYX documents in JSON-LD.
+    return '';
+  }
+
+  static getBaseURIForPhyloref(phylorefCount) {
+    // Return the base URI for a phyloreference based on its index.
+    return `${PHYXWrapper.BASE_URI}#phyloref${phylorefCount}`;
+  }
+
+  static getBaseURIForPhylogeny(phylogenyCount) {
+    // Return the base URI for phylogenies based on its index.
+    return `${PHYXWrapper.BASE_URI}#phylogeny${phylogenyCount}`;
+  }
+
+  static getBaseURIForTUMatch(countTaxonomicUnitMatches) {
+    // Return the base URI for taxonomic unit matches.
+    return `${PHYXWrapper.BASE_URI}#taxonomic_unit_match${countTaxonomicUnitMatches}`;
+  }
+
+  asJSONLD() {
+    // Export this PHYX document as a JSON-LD document. This replicates what
+    // phyx2owl.py does in the Clade Ontology.
+    //
+    // The document is mostly in JSON-LD already, except for two important
+    // things:
+    //  1. We have to convert all phylogenies into a series of statements
+    //     relating to the nodes inside these phylogenies.
+    //  2. We have to convert phylogenies into OWL restrictions.
+    //  3. Insert all matches between taxonomic units in this file.
+    //
+    const jsonld = extend(true, {}, this.phyx);
+
+    // Add descriptions for individual nodes in each phylogeny.
+    if (hasOwnProperty(jsonld, 'phylogenies')) {
+      jsonld.phylogenies = jsonld.phylogenies.map((phylogeny, countPhylogeny) =>
+        new PhylogenyWrapper(phylogeny)
+          .asJSONLD(PHYXWrapper.getBaseURIForPhylogeny(countPhylogeny)));
+    }
+
+    // Convert phyloreferences into an OWL class restriction
+    if (hasOwnProperty(jsonld, 'phylorefs')) {
+      jsonld.phylorefs = jsonld.phylorefs.map((phyloref, countPhyloref) =>
+        new PhylorefWrapper(phyloref).asJSONLD(PHYXWrapper.getBaseURIForPhyloref(countPhyloref)));
+    }
+
+    // Match all specifiers with nodes.
+    if (hasOwnProperty(jsonld, 'phylorefs') && hasOwnProperty(jsonld, 'phylogenies')) {
+      jsonld.hasTaxonomicUnitMatches = [];
+
+      // Used to create unique identifiers for each taxonomic unit match.
+      let countTaxonomicUnitMatches = 0;
+
+      jsonld.phylorefs.forEach((phylorefToChange) => {
+        const phyloref = phylorefToChange;
+        let specifiers = [];
+
+        if (hasOwnProperty(phyloref, 'internalSpecifiers')) {
+          specifiers = specifiers.concat(phyloref.internalSpecifiers);
+        }
+
+        if (hasOwnProperty(phyloref, 'externalSpecifiers')) {
+          specifiers = specifiers.concat(phyloref.externalSpecifiers);
+        }
+
+        specifiers.forEach((specifier) => {
+          if (!hasOwnProperty(specifier, 'referencesTaxonomicUnits')) return;
+          const specifierTUs = specifier.referencesTaxonomicUnits;
+          let nodesMatchedCount = 0;
+
+          jsonld.phylogenies.forEach((phylogenyToChange) => {
+            const phylogeny = phylogenyToChange;
+
+            specifierTUs.forEach((specifierTU) => {
+              phylogeny.nodes.forEach((node) => {
+                if (!hasOwnProperty(node, 'representsTaxonomicUnits')) return;
+                const nodeTUs = node.representsTaxonomicUnits;
+
+                nodeTUs.forEach((nodeTU) => {
+                  const matcher = new TaxonomicUnitMatcher(specifierTU, nodeTU);
+                  if (matcher.matched) {
+                    const tuMatchAsJSONLD =
+                      matcher.asJSONLD(PHYXWrapper.getBaseURIForTUMatch(countTaxonomicUnitMatches));
+                    jsonld.hasTaxonomicUnitMatches.push(tuMatchAsJSONLD);
+                    nodesMatchedCount += 1;
+                    countTaxonomicUnitMatches += 1;
+                  }
+                });
+              });
+            });
+          });
+
+          if (nodesMatchedCount === 0) {
+            // No nodes matched? Record this as an unmatched specifier.
+            if (!hasOwnProperty(phyloref, 'hasUnmatchedSpecifiers')) phyloref.hasUnmatchedSpecifiers = [];
+            phyloref.hasUnmatchedSpecifiers.push(specifier);
+          }
+        });
+      });
+    }
+
+    // Finally, add the base URI as an ontology.
+    jsonld['@id'] = PHYXWrapper.BASE_URI;
+    jsonld['@type'] = [PHYLOREFERENCE_TEST_CASE, 'owl:Ontology'];
+    jsonld['owl:imports'] = [
+      'http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl',
+      // - Will become 'http://vocab.phyloref.org/phyloref/testcase.owl'
+      'http://ontology.phyloref.org/2018-12-04/phyloref.owl',
+      // - The Phyloreferencing ontology.
+      'http://purl.obolibrary.org/obo/bco.owl',
+      // - Contains OWL definitions for Darwin Core terms
+    ];
+
+    // If the '@context' is missing, add it here.
+    if (!hasOwnProperty(jsonld, '@context')) {
+      jsonld['@context'] = 'http://www.phyloref.org/curation-tool/json/phyx.json';
+    }
+
+    return jsonld;
+  }
+}
+
+/* Exports */
+if (!hasOwnProperty(this, 'window')) {
+  module.exports = {
+    ScientificNameWrapper,
+    SpecimenWrapper,
+    TaxonomicUnitWrapper,
+    TaxonomicUnitMatcher,
+    PhylogenyWrapper,
+    PhylorefWrapper,
+    PHYXWrapper,
+    phyxCacheManager,
+  };
+}

--- a/index.js
+++ b/index.js
@@ -783,12 +783,12 @@ class PhylogenyWrapper {
     });
   }
 
-  getParsedNewickWithIRIs(baseURI) {
+  static getParsedNewickWithIRIs(parsedNewick, baseURI) {
     // Return the parsed Newick string, but with EVERY node given an IRI.
+    // parsedNewick: A Newick tree represented as a tree produced by Phylotree.
     // baseURI: The base URI to use for node elements (e.g. ':phylogeny1').
 
-    const newick = this.phylogeny.newick || '()';
-    const parsed = d3.layout.newick_parser(newick);
+    const parsed = parsedNewick;
     if (hasOwnProperty(parsed, 'json')) {
       PhylogenyWrapper.recurseNodes(parsed.json, (node, nodeCount) => {
         // Start with the additional node properties.
@@ -803,8 +803,9 @@ class PhylogenyWrapper {
     return parsed;
   }
 
-  getNodesAsJSONLD(baseURI) {
+  static getNodesAsJSONLD(parsedNewick, baseURI) {
     // Returns a list of all nodes in this phylogeny as a series of nodes.
+    // - parsedNewick: A Newick tree parsed into a tree structure by Phylotree.
     // - baseURI: The base URI to use for node elements (e.g. ':phylogeny1').
 
     // List of nodes we have identified.
@@ -820,7 +821,7 @@ class PhylogenyWrapper {
     // Parse the Newick string; if parseable, recurse through the nodes,
     // added them to the list of JSON-LD nodes as we go.
 
-    const parsed = this.getParsedNewickWithIRIs(baseURI);
+    const parsed = this.getParsedNewickWithIRIs(parsedNewick, baseURI);
     if (hasOwnProperty(parsed, 'json')) {
       PhylogenyWrapper.recurseNodes(parsed.json, (node, nodeCount, parentCount) => {
         // Start with the additional node properties.

--- a/index.js
+++ b/index.js
@@ -20,13 +20,13 @@
  * can be complex and slow if necessary.
  */
 
-// TODO: remove references to Vue but make sure it still works from within Vue.
-import phylotree from 'phylotree';
-    // TODO: phylotree requires bootstrap, which seems excessive, but our
-    // current code is designed to work on its particular internal structure.
-    // It might be worth moving that code into the Curation Tool, and replacing
-    // this prerequestive with https://www.npmjs.com/package/newick-js
+// Used to parse Newick strings.
+const { parse: parseNewick } = require('newick-js');
+
+// Used to parse timestamps for phyloref statuses.
 import moment from 'moment';
+
+// Used to make deep copies of objects.
 import extend from 'extend';
 
 // Some OWL constants to be used.
@@ -619,13 +619,13 @@ class PhylogenyWrapper {
       });
     }
 
-    // Finally, try parsing it with newick_parser and see if we get an error.
-    const parsed = d3.layout.newick_parser(newickTrimmed);
-    if (!hasOwnProperty(parsed, 'json') || parsed.json === null) {
-      const error = (hasOwnProperty(parsed, 'error') ? parsed.error : 'unknown error');
+    // Finally, try parsing it with parseNewick and see if we get an error.
+    try {
+      parseNewick(newickTrimmed);
+    } catch (ex) {
       errors.push({
         title: 'Error parsing phylogeny',
-        message: `An error occured while parsing this phylogeny: ${error}`,
+        message: `An error occured while parsing this phylogeny: ${ex.message}`,
       });
     }
 
@@ -688,41 +688,54 @@ class PhylogenyWrapper {
   }
 
   getNodeLabels(nodeType = 'both') {
-    // Return a list of all the node labels in a phylogeny.
+    // Return a list of all the node labels in this phylogeny.
     //
     // nodeType can be one of:
     // - 'internal': Return node labels on internal nodes.
     // - 'terminal': Return node labels on terminal nodes.
     // - 'both': Return node labels on both internal and terminal nodes.
 
-    const nodeLabels = new Set();
+    // Parse the phylogeny (will throw an exception if parsing failed).
+    const { graph } = parseNewick(this.phylogeny.newick || '()');
+    const [vertices, arcs] = graph;
 
-    // Names from the Newick string.
-    const newick = this.phylogeny.newick || '()';
-
-    // Parse the Newick string; if parseable, recurse through the node labels,
-    // adding them all to 'nodeLabels'.
-    const parsed = d3.layout.newick_parser(newick);
-    if (hasOwnProperty(parsed, 'json') && parsed.json !== null) {
-      // Recurse away!
-      PhylogenyWrapper.recurseNodes(parsed.json, (node) => {
-        if (hasOwnProperty(node, 'name') && node.name !== '') {
-          const nodeHasChildren = hasOwnProperty(node, 'children') && node.children.length > 0;
-
-          // Only add the node label if it is on the type of node
-          // we're interested in.
-          if (
-            (nodeType === 'both') ||
-            (nodeType === 'internal' && nodeHasChildren) ||
-            (nodeType === 'terminal' && !nodeHasChildren)
-          ) {
-            nodeLabels.add(node.name);
-          }
-        }
-      });
+    if (nodeType === 'both') {
+      // Return all node labels.
+      return Array.from(
+        new Set(
+          Array.from(vertices)
+            .map(vertex => vertex.label)
+            .filter(label => label !== undefined),
+        ),
+      );
     }
 
-    return Array.from(nodeLabels);
+    if (nodeType === 'internal') {
+      // Return the internal nodes (those with atleast one child).
+      return Array.from(new Set(
+        Array.from(arcs)
+          .map(arc => arc[0].label) // Retrieve the label of the parent vertex in this arc.
+          .filter(label => label !== undefined),
+      ));
+    }
+
+    if (nodeType === 'terminal') {
+      // Return the terminal nodes. This would require calculating the children
+      // of every vertex in the graph and then identifying vertices without any
+      // children.
+      //
+      // A quicker and dirtier way to do this is by removing internal labels
+      // from the list of all node labels. This will report an incorrect result
+      // if an internal node has the same label as a terminal node, but at that
+      // point a lot of other assumptions are going to fail, too, so this is
+      // probably good enough for now.
+      const allLabels = this.getNodeLabels('both');
+      const internalLabels = new Set(this.getNodeLabels('internal'));
+
+      return allLabels.filter(label => !internalLabels.has(label));
+    }
+
+    throw new Error(`Unknown nodeType: '${nodeType}'`);
   }
 
   getTaxonomicUnitsForNodeLabel(nodeLabel) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@phyloref/phyx",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1652 @@
+{
+  "name": "@phyloref/phyx",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "acorn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+      "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+      "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bootstrap": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.2.1.tgz",
+      "integrity": "sha512-tt/7vIv3Gm2mnd/WeDx36nfGGHleil0Wg8IeB7eMrVkY0fZ5iTaBisSh8oNANc2IBsCc6vCgCNTIM/IEN0+50Q=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+      "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "d3": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.0.tgz",
+      "integrity": "sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.1.0",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.0.2",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz",
+      "integrity": "sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==",
+      "dev": true,
+      "requires": {
+        "eslint-restricted-globals": "^0.1.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "dev": true,
+      "requires": {
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.2.0",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-mocha": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-5.2.1.tgz",
+      "integrity": "sha512-v95cxwpPiyt2Gb/Moog8KQtaT+KlGGMbqpOkcP/eIkvaovPEcTprOYywAOo1On+KDsfEbJ4mByfcfUEwrxH9Gw==",
+      "dev": true,
+      "requires": {
+        "ramda": "^0.26.1"
+      }
+    },
+    "eslint-restricted-globals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      }
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+      "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "moment": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
+      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "^2.0.0"
+      }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "phylotree": {
+      "version": "0.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/phylotree/-/phylotree-0.2.0-alpha.1.tgz",
+      "integrity": "sha512-gYiSK3rWglWKJdkbzXxLspu9gctKJwobYHcqlqj2OeV3aAyOFIvtGcHzmFzIxTE0+0c3NFrshZlHRudY10bu1A==",
+      "requires": {
+        "bootstrap": "4",
+        "d3": "3.x",
+        "font-awesome": "4.x",
+        "jquery": "3",
+        "underscore": "1.x",
+        "xml2js": "^0.4.19"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        }
+      }
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
+      "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.2.1.tgz",
+      "integrity": "sha512-qmhNs2GEHNqY5fd2Mo+8N1r2sw/rvTAAvBZTaTx+Y7PHLypqyrxr1MdIu0pLw6Xvl/Gi4ONu/sdceP8vvUjkyA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.6.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "2.0.0",
+        "string-width": "^2.1.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,11 +96,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bootstrap": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.2.1.tgz",
-      "integrity": "sha512-tt/7vIv3Gm2mnd/WeDx36nfGGHleil0Wg8IeB7eMrVkY0fZ5iTaBisSh8oNANc2IBsCc6vCgCNTIM/IEN0+50Q=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -232,11 +227,6 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
-    },
-    "d3": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
-      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
     },
     "debug": {
       "version": "3.1.0",
@@ -639,11 +629,6 @@
         "write": "^0.2.1"
       }
     },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -887,11 +872,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1037,6 +1017,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "newick-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/newick-js/-/newick-js-1.1.0.tgz",
+      "integrity": "sha512-lIdQGwqVD3x6kPK/kANgIM4oMZd/OmnxbaJRp0eycZoSNcAjyMshGyW5RVKsmVhkd69RNfwDqj+0/nwf7m3k6A=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -1220,19 +1205,6 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
-    "phylotree": {
-      "version": "0.2.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/phylotree/-/phylotree-0.2.0-alpha.1.tgz",
-      "integrity": "sha512-gYiSK3rWglWKJdkbzXxLspu9gctKJwobYHcqlqj2OeV3aAyOFIvtGcHzmFzIxTE0+0c3NFrshZlHRudY10bu1A==",
-      "requires": {
-        "bootstrap": "4",
-        "d3": "3.x",
-        "font-awesome": "4.x",
-        "jquery": "3",
-        "underscore": "1.x",
-        "xml2js": "^0.4.19"
-      }
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -1405,11 +1377,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -1580,11 +1547,6 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -1633,20 +1595,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@phyloref/phyx",
+  "version": "1.0.0",
+  "description": "Phyloreference Exchange (PHYX) library in JavaScript",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint index.js \"test/**\" --ext .js",
+    "pretest": "npm run lint",
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phyloref/phyx.js.git"
+  },
+  "keywords": [
+    "phylogenetics",
+    "phylogeny",
+    "phylogenetic definitions",
+    "clade definitions"
+  ],
+  "author": "Gaurav Vaidya <gaurav@ggvaidya.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/phyloref/phyx.js/issues"
+  },
+  "homepage": "https://github.com/phyloref/phyx.js#readme",
+  "dependencies": {
+    "extend": "^3.0.2",
+    "moment": "^2.23.0",
+    "phylotree": "^0.2.0-alpha.1"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "eslint": "^5.12.0",
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-mocha": "^5.2.1",
+    "mocha": "^5.2.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phyloref/phyx",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Phyloreference Exchange (PHYX) library in JavaScript",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phyloref/phyx",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Phyloreference Exchange (PHYX) library in JavaScript",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "extend": "^3.0.2",
     "moment": "^2.23.0",
-    "phylotree": "^0.2.0-alpha.1"
+    "newick-js": "^1.1.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "prefer-arrow-callback": "off",
+    "func-names": "off",
+    "no-unused-expressions": "off"
+  }
+}

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -92,7 +92,7 @@ describe('PhylogenyWrapper', function () {
 
     describe('when given an incomplete Newick string', function () {
       const incompleteNewickStrings = [
-        '(;)',
+        ';',
         '))(A, (B, ',
       ];
 
@@ -145,7 +145,7 @@ describe('PhylogenyWrapper', function () {
 
   describe('given a particular phylogeny with additional node properties', function () {
     const wrapper = new phyx.PhylogenyWrapper({
-      newick: '((MVZ225749, MVZ191016), "Rana boylii")',
+      newick: '((MVZ225749, MVZ191016), Rana boylii)',
       additionalNodeProperties: {
         MVZ225749: {
           representsTaxonomicUnits: [{
@@ -169,7 +169,6 @@ describe('PhylogenyWrapper', function () {
             'MVZ191016',
             'MVZ225749',
             'Rana boylii',
-            'root',
           ]);
       });
     });

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -1,0 +1,240 @@
+/*
+ * Test phylogenies.
+ */
+
+// Load phyx.js, our PHYX library, and chai for testing.
+const phyx = require('..');
+const chai = require('chai');
+
+// Use Chai's expect API for testing.
+const expect = chai.expect;
+
+/*
+ * These tests focus on three aspects of PhylogenyWrapper:
+ *  - Whether it can detect errors in an input Newick string.
+ *  - Retrieve taxonomic units from the phylogeny based on either their node label
+ *    or on the additional properties associated with the phylogeny.
+ *  - Whether we can match specifiers with nodes on the phylogeny if they share
+ *    taxonomic units that match.
+ */
+
+describe('PhylogenyWrapper', function () {
+  describe('#constructor', function () {
+    describe('when used to wrap an empty object', function () {
+      it('should return a PhylogenyWrapper object', function () {
+        expect(new phyx.PhylogenyWrapper({}))
+          .to.be.an.instanceOf(phyx.PhylogenyWrapper);
+      });
+    });
+  });
+
+  describe('#getErrorsInNewickString', function () {
+    describe('when given a correct Newick string', function () {
+      const correctNewickStrings = [
+        '(A:3, B:5, (C:6, N:7));',
+      ];
+
+      it('should return an empty list of errors', function () {
+        correctNewickStrings.forEach((str) => {
+          expect(phyx.PhylogenyWrapper.getErrorsInNewickString(str)).to.be.empty;
+        });
+      });
+    });
+
+    describe('when given an empty Newick string', function () {
+      const emptyNewickStrings = [
+        '()',
+        '();  ',
+      ];
+
+      it('should return a single "No phylogeny entered" error', function () {
+        emptyNewickStrings.forEach((newick) => {
+          const errors = phyx.PhylogenyWrapper.getErrorsInNewickString(newick);
+          expect(errors).to.have.length(1);
+          expect(errors[0].title).to.equal('No phylogeny entered');
+        });
+      });
+    });
+
+    describe('when given an unbalanced Newick string', function () {
+      const unbalancedNewickString = [
+        {
+          newick: '(A, B))',
+          expected: 'You have 1 too few open parentheses',
+        },
+        {
+          newick: '(A, (B, (C, D))',
+          expected: 'You have 1 too many open parentheses',
+        },
+        {
+          newick: '(A, (B, (C, (((D))',
+          expected: 'You have 4 too many open parentheses',
+        },
+      ];
+
+      it('should report how many parentheses are missing', function () {
+        unbalancedNewickString.forEach((entry) => {
+          const errors = phyx.PhylogenyWrapper.getErrorsInNewickString(entry.newick);
+
+          // We should get two errors.
+          expect(errors).to.have.lengthOf(2);
+
+          // Should include an error about the unbalanced parentheses.
+          expect(errors[0].title).to.equal('Unbalanced parentheses in Newick string');
+          expect(errors[0].message).to.equal(entry.expected);
+
+          // Should include an error passed on from the Newick parser.
+          expect(errors[1].title).to.equal('Error parsing phylogeny');
+          expect(errors[1].message).to.include('An error occured while parsing this phylogeny:');
+        });
+      });
+    });
+
+    describe('when given an incomplete Newick string', function () {
+      const incompleteNewickStrings = [
+        '(;)',
+        '))(A, (B, ',
+      ];
+
+      it('should report an error parsing the phylogeny', function () {
+        incompleteNewickStrings.forEach((newick) => {
+          const errors = phyx.PhylogenyWrapper.getErrorsInNewickString(newick);
+
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].title).to.equal('Error parsing phylogeny');
+          expect(errors[0].message).to.include('An error occured while parsing this phylogeny:');
+        });
+      });
+    });
+  });
+
+  describe('#getNodeLabels', function () {
+    const tests = [
+      {
+        // Note that 'newick' is the input for this test.
+        newick: '(A, (B, (C, D))E, F, (G, (H, I, J)K, L)M, N)O',
+        // The following keys indicate the expected all/internal/terminal node labels
+        // for the given Newick string.
+        nodeLabels: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O'],
+        internalNodeLabels: ['E', 'K', 'M', 'O'],
+        terminalNodeLabels: ['A', 'B', 'C', 'D', 'F', 'G', 'H', 'I', 'J', 'L', 'N'],
+      },
+    ];
+
+    tests.forEach((test) => {
+      const wrapper = new phyx.PhylogenyWrapper({ newick: test.newick });
+
+      describe('For a particular Newick phylogeny', function () {
+        it('should return a list of all node labels by default', function () {
+          expect(wrapper.getNodeLabels().sort())
+            .to.have.members(test.nodeLabels.sort());
+        });
+
+        it('should return a list of internal labels when asked for internal labels', function () {
+          expect(wrapper.getNodeLabels('internal').sort())
+            .to.have.members(test.internalNodeLabels.sort());
+        });
+
+        it('should return a list of terminal labels when asked for terminal labels', function () {
+          expect(wrapper.getNodeLabels('terminal').sort())
+            .to.have.members(test.terminalNodeLabels.sort());
+        });
+      });
+    });
+  });
+
+  describe('given a particular phylogeny with additional node properties', function () {
+    const wrapper = new phyx.PhylogenyWrapper({
+      newick: '((MVZ225749, MVZ191016), "Rana boylii")',
+      additionalNodeProperties: {
+        MVZ225749: {
+          representsTaxonomicUnits: [{
+            scientificNames: [{ scientificName: 'Rana luteiventris' }],
+            includesSpecimens: [{ occurrenceID: 'MVZ:225749' }],
+          }],
+        },
+        MVZ191016: {
+          representsTaxonomicUnits: [{
+            scientificNames: [{ scientificName: 'Rana luteiventris' }],
+            includesSpecimens: [{ occurrenceID: 'MVZ:191016' }],
+          }],
+        },
+      },
+    });
+
+    describe('#getNodeLabels', function () {
+      it('should return the list of node labels from the Newick string', function () {
+        expect(wrapper.getNodeLabels().sort())
+          .to.have.members([
+            'MVZ191016',
+            'MVZ225749',
+            'Rana boylii',
+            'root',
+          ]);
+      });
+    });
+
+    describe('#getTaxonomicUnitsForNodeLabel', function () {
+      it('should return the list of taxonomic units using information from additional node properties', function () {
+        expect(wrapper.getTaxonomicUnitsForNodeLabel('MVZ191016')).to.deep.equal([{
+          scientificNames: [{ scientificName: 'Rana luteiventris' }],
+          includesSpecimens: [{ occurrenceID: 'MVZ:191016' }],
+        }]);
+
+        expect(wrapper.getTaxonomicUnitsForNodeLabel('MVZ225749')).to.deep.equal([{
+          scientificNames: [{ scientificName: 'Rana luteiventris' }],
+          includesSpecimens: [{ occurrenceID: 'MVZ:225749' }],
+        }]);
+
+        expect(wrapper.getTaxonomicUnitsForNodeLabel('Rana boylii')).to.deep.equal([{
+          scientificNames: [{
+            scientificName: 'Rana boylii',
+            binomialName: 'Rana boylii',
+            genus: 'Rana',
+            specificEpithet: 'boylii',
+          }],
+        }]);
+      });
+    });
+
+    describe('#getNodeLabelsMatchedBySpecifier', function () {
+      it('should match a specifier to MVZ225749 based on occurrence ID', function () {
+        const specifier1 = {
+          referencesTaxonomicUnits: [{
+            includesSpecimens: [{
+              occurrenceID: 'MVZ:225749',
+            }],
+          }],
+        };
+        expect(wrapper.getNodeLabelsMatchedBySpecifier(specifier1))
+          .to.have.members(['MVZ225749']);
+      });
+
+      it('should match a specifier to MVZ191016 based on occurrence ID', function () {
+        const specifier2 = {
+          referencesTaxonomicUnits: [{
+            includesSpecimens: [{
+              occurrenceID: 'MVZ:191016',
+            }],
+          }],
+        };
+
+        expect(wrapper.getNodeLabelsMatchedBySpecifier(specifier2))
+          .to.have.members(['MVZ191016']);
+      });
+
+      it('should match a specifier to node "Rana boylii" based on the parsed scientific name', function () {
+        const specifier3 = {
+          referencesTaxonomicUnits: [{
+            scientificNames: [{
+              scientificName: 'Rana boyli',
+            }],
+          }],
+        };
+
+        expect(wrapper.getNodeLabelsMatchedBySpecifier(specifier3))
+          .to.have.members([]);
+      });
+    });
+  });
+});

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -170,7 +170,7 @@ describe('PhylorefWrapper', function () {
           .to.throw(
             TypeError,
             'setStatus() called with invalid status CURIE \'pso:retracted-from_publication\'',
-            'PhylorefWrapper throws TypeError on a mistyped status',
+            'PhylorefWrapper throws TypeError on a mistyped status'
           );
       });
     });

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -1,0 +1,203 @@
+/*
+ * Test phyloreferences.
+ */
+
+// Require phyx.js, our PHYX library, and Chai for testing.
+const phyx = require('..');
+const chai = require('chai');
+
+// We use Chai's Expect API.
+const expect = chai.expect;
+
+/*
+ * Phyloref tests cover three aspects of phyloreferences:
+ *  - Whether we can create a phyloref with a particular set of specifiers,
+ *    and whether we can correctly change the type of a specifer (from 'External'
+ *    to 'Internal'), delete specifiers, and retrieve specifier labels.
+ *  - Whether we can determine to which node a phyloref is expected to resolve to
+ *    by using additionalNodeProperties.
+ *  - Whether we can update the phyloref's status several times and retrieve the
+ *    full history of its status changes.
+ */
+
+describe('PhylorefWrapper', function () {
+  // Some specifiers to use in testing.
+  const specifier1 = {
+    referencesTaxonomicUnits: [{
+      includesSpecimens: [{
+        occurrenceID: 'MVZ:225749',
+      }],
+    }],
+  };
+  const specifier2 = {
+    referencesTaxonomicUnits: [{
+      includesSpecimens: [{
+        occurrenceID: 'MVZ:191016',
+      }],
+    }],
+  };
+  const specifier3 = {
+    referencesTaxonomicUnits: [{
+      scientificNames: [{
+        scientificName: 'Rana boylii',
+      }],
+    }],
+  };
+
+  describe('given an empty phyloreference', function () {
+    const wrapper = new phyx.PhylorefWrapper({});
+
+    describe('#constructor', function () {
+      it('should return a PhylorefWrapper', function () {
+        expect(wrapper).to.be.an.instanceOf(phyx.PhylorefWrapper);
+      });
+    });
+
+    describe('#label', function () {
+      it('should return undefined', function () {
+        expect(wrapper.label).to.be.undefined;
+      });
+
+      it('should be settable by assigning to .label', function () {
+        wrapper.label = 'phyloref1';
+        expect(wrapper.label).equals('phyloref1');
+      });
+    });
+
+    describe('#specifiers', function () {
+      it('should initially return an empty list', function () {
+        expect(wrapper.specifiers).to.be.empty;
+      });
+
+      describe('when a new external specifier is added using .externalSpecifiers', function () {
+        it('should return a list with the new specifier', function () {
+          wrapper.phyloref.externalSpecifiers.push(specifier3);
+          expect(wrapper.specifiers).to.deep.equal([specifier3]);
+        });
+      });
+
+      describe('when a new external specifier is added using .externalSpecifiers', function () {
+        it('should return a list with the new specifier', function () {
+          wrapper.phyloref.externalSpecifiers.push(specifier2);
+          expect(wrapper.specifiers).to.deep.equal([specifier3, specifier2]);
+        });
+      });
+
+      describe('when a specifier is deleted using .deleteSpecifier', function () {
+        it('should return the updated list', function () {
+          wrapper.deleteSpecifier(specifier2);
+          expect(wrapper.specifiers).to.deep.equal([specifier3]);
+        });
+      });
+
+      describe('when a specifier is added using .externalSpecifiers', function () {
+        it('should return the updated list', function () {
+          wrapper.phyloref.externalSpecifiers.push(specifier1);
+          expect(wrapper.specifiers).to.deep.equal([specifier3, specifier1]);
+        });
+      });
+
+      describe('when a specifier is changed to an internal specifier using .setSpecifierType', function () {
+        it('should remain in the list of specifiers', function () {
+          wrapper.setSpecifierType(specifier1, 'Internal');
+          expect(wrapper.specifiers).to.deep.equal([specifier1, specifier3]);
+        });
+      });
+
+      describe('when a specifier is added using .internalSpecifiers', function () {
+        it('should be included in the list of all specifiers', function () {
+          wrapper.phyloref.internalSpecifiers.push(specifier2);
+          expect(wrapper.specifiers).to.deep.equal([specifier1, specifier2, specifier3]);
+        });
+      });
+    });
+
+    describe('#getSpecifierType', function () {
+      it('should return the correct specifier type for each specifier', function () {
+        expect(wrapper.getSpecifierType(specifier1)).to.equal('Internal');
+        expect(wrapper.getSpecifierType(specifier2)).to.equal('Internal');
+        expect(wrapper.getSpecifierType(specifier3)).to.equal('External');
+      });
+    });
+
+    describe('#getSpecifierLabel', function () {
+      it('should return the correct label for each specifier', function () {
+        expect(phyx.PhylorefWrapper.getSpecifierLabel(specifier1)).to.equal('Specimen MVZ:225749');
+        expect(phyx.PhylorefWrapper.getSpecifierLabel(specifier2)).to.equal('Specimen MVZ:191016');
+        expect(phyx.PhylorefWrapper.getSpecifierLabel(specifier3)).to.equal('Rana boylii');
+      });
+    });
+  });
+
+  describe('given a particular phylogeny', function () {
+    // Some phylogenies to use in testing.
+    const phylogeny1 = {
+      newick: '((MVZ225749, MVZ191016)Test, "Rana boylii")',
+      additionalNodeProperties: {
+        Test: {
+          expectedPhyloreferenceNamed: 'phyloref1',
+        },
+      },
+    };
+
+    describe('#getExpectedNodeLabels', function () {
+      it('should be able to determine expected node labels for a phylogeny', function () {
+        const phyloref1 = new phyx.PhylorefWrapper({
+          label: 'phyloref1',
+          internalSpecifiers: [specifier1, specifier2],
+          externalSpecifiers: [specifier3],
+        });
+
+        expect(phyloref1.getExpectedNodeLabels(phylogeny1))
+          .to.deep.equal(['Test']);
+      });
+    });
+  });
+
+  describe('given an empty phyloreference', function () {
+    const wrapper = new phyx.PhylorefWrapper({});
+
+    describe('#getCurrentStatus', function () {
+      it('should return "pso:draft" as the default initial status', function () {
+        // Initially, an empty phyloref should report a status of 'pso:draft'.
+        expect(wrapper.getCurrentStatus().statusCURIE).to.equal('pso:draft');
+      });
+    });
+
+    describe('#setStatus', function () {
+      it('should throw an error if given a mistyped status', function () {
+        expect(function () { wrapper.setStatus('pso:retracted-from_publication'); })
+          .to.throw(
+            TypeError,
+            'setStatus() called with invalid status CURIE \'pso:retracted-from_publication\'',
+            'PhylorefWrapper throws TypeError on a mistyped status',
+          );
+      });
+    });
+
+    describe('#getStatusChanges', function () {
+      it('should return the empty list', function () {
+        expect(wrapper.getStatusChanges()).to.be.empty;
+      });
+
+      describe('when modified by using .setStatus', function () {
+        it('should return the updated list', function () {
+          wrapper.setStatus('pso:final-draft');
+          wrapper.setStatus('pso:under-review');
+          wrapper.setStatus('pso:submitted');
+          wrapper.setStatus('pso:published');
+          wrapper.setStatus('pso:retracted-from-publication');
+
+          // And see if we get the statuses back in the correct order.
+          const statusChanges = wrapper.getStatusChanges();
+          expect(statusChanges.length, 'number of status changes should be 5').to.equal(5);
+          expect(statusChanges[0].statusCURIE, 'first status change should be "pso:final-draft"').to.equal('pso:final-draft');
+          expect(statusChanges[1].statusCURIE, 'second status change should be "pso:under-review"').to.equal('pso:under-review');
+          expect(statusChanges[2].statusCURIE, 'third status change should be a "pso:submitted"').to.equal('pso:submitted');
+          expect(statusChanges[3].statusCURIE, 'fourth status change should be a "pso:published"').to.equal('pso:published');
+          expect(statusChanges[4].statusCURIE, 'fifth status change should be a "pso:retracted-from-publication"').to.equal('pso:retracted-from-publication');
+        });
+      });
+    });
+  });
+});

--- a/test/scientific-names.js
+++ b/test/scientific-names.js
@@ -1,0 +1,47 @@
+/*
+ * Test scientific name processing.
+ */
+
+const chai = require('chai');
+const phyx = require('..');
+
+const expect = chai.expect;
+
+/*
+ * Test whether ScientificNameWrapper parses scientific names correctly.
+ */
+
+describe('ScientificNameWrapper', function () {
+  describe('#constructor', function () {
+    it('should accept empty scientific names without errors', function () {
+      const wrapper = new phyx.ScientificNameWrapper({});
+
+      expect(wrapper).to.be.an.instanceOf(phyx.ScientificNameWrapper);
+      expect(wrapper.scientificName).to.be.undefined;
+    });
+    it('should be able to parse uninomial names as genus names without a specific epithet', function () {
+      const wrapper = new phyx.ScientificNameWrapper({
+        scientificName: 'Mus',
+      });
+
+      expect(wrapper.genus).to.equal('Mus');
+      expect(wrapper.specificEpithet).to.be.undefined;
+    });
+    it('should be able to parse binomial names into genus and specific epithet', function () {
+      const wrapper = new phyx.ScientificNameWrapper({
+        scientificName: 'Mus musculus',
+      });
+
+      expect(wrapper.genus).to.equal('Mus');
+      expect(wrapper.specificEpithet).to.equal('musculus');
+    });
+    it('should ignore authority after a binomial name', function () {
+      const wrapper = new phyx.ScientificNameWrapper({
+        scientificName: 'Mus musculus Linnaeus, 1758',
+      });
+
+      expect(wrapper.genus).to.equal('Mus');
+      expect(wrapper.specificEpithet).to.equal('musculus');
+    });
+  });
+});

--- a/test/specimens.js
+++ b/test/specimens.js
@@ -1,0 +1,73 @@
+/*
+ * Test specimen processing.
+ */
+
+const chai = require('chai');
+const phyx = require('..');
+
+const expect = chai.expect;
+
+/*
+ * Test whether SpecimenWrapper can parse specimen identifiers from simple specimen
+ * identifiers, from institutionCode:catalogNumber format, and from Darwin Core triples.
+ * However, URNs and HTTP URLs should not be accidentally parsed as Darwin Core triples.
+ */
+
+describe('SpecimenWrapper', function () {
+  describe('#constructor', function () {
+    it('should be able to wrap an empty specimen', function () {
+      const wrapped = new phyx.SpecimenWrapper({});
+
+      expect(wrapped).to.be.an.instanceOf(phyx.SpecimenWrapper);
+      expect(wrapped.occurrenceID).to.equal('urn:catalog:::');
+    });
+    it('should be able to extract an occurenceID and catalogNumber from simple specimen IDs', function () {
+      const wrapper = new phyx.SpecimenWrapper({
+        occurrenceID: 'Wall 2527, Fiji (uc)',
+      });
+      expect(wrapper.occurrenceID).to.equal('Wall 2527, Fiji (uc)');
+      expect(wrapper.catalogNumber).to.equal('Wall 2527, Fiji (uc)');
+    });
+    it('should extract institutionCode and catalogNumber from a institutionCode:catalogNumber combination', function () {
+      const wrapper = new phyx.SpecimenWrapper({
+        occurrenceID: 'FMNH:PR 2081',
+      });
+      expect(wrapper.occurrenceID).to.equal('FMNH:PR 2081');
+      expect(wrapper.institutionCode).to.equal('FMNH');
+      expect(wrapper.catalogNumber).to.equal('PR 2081');
+    });
+    it('should extract occurenceID, institutionCode and catalogNumber from Darwin Core triples', function () {
+      const wrapper = new phyx.SpecimenWrapper({
+        occurrenceID: 'FMNH:PR:2081',
+      });
+      expect(wrapper.occurrenceID).to.equal('FMNH:PR:2081');
+      expect(wrapper.institutionCode).to.equal('FMNH');
+      expect(wrapper.collectionCode).to.equal('PR');
+      expect(wrapper.catalogNumber).to.equal('2081');
+    });
+    it('should be able to extract the same occurrenceID from different representations', function () {
+      expect(new phyx.SpecimenWrapper({ occurrenceID: 'urn:catalog:::MVZ225749' }).occurrenceID)
+        .to.equal('urn:catalog:::MVZ225749');
+      expect(new phyx.SpecimenWrapper({ catalogNumber: 'MVZ225749' }).occurrenceID)
+        .to.equal('urn:catalog:::MVZ225749');
+    });
+    it('should not attempt to split a URN into occurenceID, institutionCode and catalogNumber', function () {
+      const wrapper = new phyx.SpecimenWrapper({
+        occurrenceID: 'urn:lsid:biocol.org:col:34777',
+      });
+      expect(wrapper.occurrenceID).to.equal('urn:lsid:biocol.org:col:34777');
+      expect(wrapper.institutionCode).to.be.undefined;
+      expect(wrapper.collectionCode).to.be.undefined;
+      expect(wrapper.catalogNumber).to.be.undefined;
+    });
+    it('should not attempt to split a URL into occurenceID, institutionCode and catalogNumber', function () {
+      const wrapper = new phyx.SpecimenWrapper({
+        occurrenceID: 'http://arctos.database.museum/guid/MVZ:Herp:148929?seid=886464',
+      });
+      expect(wrapper.occurrenceID).to.equal('http://arctos.database.museum/guid/MVZ:Herp:148929?seid=886464');
+      expect(wrapper.institutionCode).to.be.undefined;
+      expect(wrapper.collectionCode).to.be.undefined;
+      expect(wrapper.catalogNumber).to.be.undefined;
+    });
+  });
+});

--- a/test/taxonomic-units.js
+++ b/test/taxonomic-units.js
@@ -1,0 +1,185 @@
+/*
+ * Test taxonomic unit construction and matching.
+ */
+
+const chai = require('chai');
+const phyx = require('..');
+
+// Use Chai's expect API.
+const expect = chai.expect;
+
+/*
+ * We primarily test two classes here:
+ *  - TaxonomicUnitWrapper, which wraps a taxonomic unit and determines if it
+ *    refers to a scientific name, specimen identifier or external reference,
+ *    or a combination of these.
+ *  - TaxonomicUnitMatcher, which accepts two taxonomic units and determines
+ *    whether and for what reason the two can be matched.
+ */
+
+describe('TaxonomicUnitWrapper', function () {
+  describe('#constructor given no arguments', function () {
+    it('should create an empty TaxonomicUnitWrapper without a defined label', function () {
+      const wrapper = new phyx.TaxonomicUnitWrapper({});
+      expect(wrapper).to.be.instanceOf(phyx.TaxonomicUnitWrapper);
+      expect(wrapper.label).to.be.undefined;
+    });
+  });
+  describe('#label given a taxonomic unit', function () {
+    it('should return a wrapped scientific name', function () {
+      const wrapper = new phyx.TaxonomicUnitWrapper({
+        scientificNames: [{
+          scientificName: 'Ornithorhynchus anatinus (Shaw, 1799)',
+        }],
+      });
+      expect(wrapper.label).to.equal('Ornithorhynchus anatinus (Shaw, 1799)');
+    });
+    it('should return two wrapped scientific names separated by "or"', function () {
+      const wrapper = new phyx.TaxonomicUnitWrapper({
+        scientificNames: [{
+          scientificName: 'Ornithorhynchus anatinus (Shaw, 1799)',
+        }, {
+          scientificName: 'Ornithorhynchus paradoxus Blumenbach, 1800',
+        }],
+      });
+      expect(wrapper.label).to.equal('Ornithorhynchus anatinus (Shaw, 1799) or Ornithorhynchus paradoxus Blumenbach, 1800');
+    });
+    it('should return a wrapped specimen identifier preceded by "Specimen"', function () {
+      const wrapper = new phyx.TaxonomicUnitWrapper({
+        includesSpecimens: [{
+          institutionCode: 'MVZ',
+          catalogNumber: '225749',
+        }],
+      });
+      expect(wrapper.label).to.equal('Specimen urn:catalog:MVZ::225749');
+    });
+    it('should return specimen identifiers and scientific names concatenated with "or"', function () {
+      const wrapper = new phyx.TaxonomicUnitWrapper({
+        scientificNames: [{
+          scientificName: 'Rana luteiventris',
+        }],
+        includesSpecimens: [{
+          institutionCode: 'MVZ',
+          catalogNumber: '225749',
+        }],
+      });
+      expect(wrapper.label).to.equal('Specimen urn:catalog:MVZ::225749 or Rana luteiventris');
+    });
+    it('should return a wrapped external reference by surrounding it with "<>"', function () {
+      const wrapper = new phyx.TaxonomicUnitWrapper({
+        externalReferences: [
+          'http://arctos.database.museum/guid/MVZ:Herp:225749',
+        ],
+      });
+      expect(wrapper.label).to.equal('<http://arctos.database.museum/guid/MVZ:Herp:225749>');
+    });
+    it('should concatenate specimen identifiers, external references and scientific names with "or"', function () {
+      const wrapper = new phyx.TaxonomicUnitWrapper({
+        externalReferences: [
+          'http://arctos.database.museum/guid/MVZ:Herp:225749',
+        ],
+        scientificNames: [{
+          scientificName: 'Rana luteiventris',
+        }],
+        includesSpecimens: [{
+          institutionCode: 'MVZ',
+          catalogNumber: '225749',
+        }],
+      });
+      expect(wrapper.label)
+        .to.equal('Specimen urn:catalog:MVZ::225749 or <http://arctos.database.museum/guid/MVZ:Herp:225749> or Rana luteiventris');
+    });
+  });
+  describe('#getTaxonomicUnitsFromNodeLabel', function () {
+    it('should return empty lists when inputs are empty or undefined', function () {
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel()).to.be.empty;
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel(undefined)).to.be.empty;
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel(null)).to.be.empty;
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('')).to.be.empty;
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('    ')).to.be.empty;
+    });
+    it('when given a scientific name, it should return a list of a single TU wrapping a scientific name', function () {
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('Rana luteiventris MVZ225749'))
+        .to.be.deep.equal([{
+          scientificNames: [{
+            scientificName: 'Rana luteiventris MVZ225749',
+            genus: 'Rana',
+            specificEpithet: 'luteiventris',
+            binomialName: 'Rana luteiventris',
+          }],
+        }]);
+    });
+    it('when given a scientific name separated with underscores, it should return a list of a single TU wrapping the scientific name', function () {
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('Rana_luteiventris_MVZ_225749'))
+        .to.be.deep.equal([{
+          scientificNames: [{
+            scientificName: 'Rana luteiventris MVZ_225749',
+            genus: 'Rana',
+            specificEpithet: 'luteiventris',
+            binomialName: 'Rana luteiventris',
+          }],
+        }]);
+    });
+  });
+});
+
+describe('TaxonomicUnitMarcher', function () {
+  // To test matching, let's set up some taxonomic units.
+  // Note that:
+  //  tunit1 and tunit2 should match by scientific name.
+  //  tunit2 and tunit3 should match by specimen identifier.
+  //  tunit3 and tunit4 should match by external references.
+  const tunit1 = { scientificNames: [{ scientificName: 'Rana luteiventris' }] };
+  const tunit2 = {
+    scientificNames: [{ scientificName: 'Rana luteiventris MVZ225749' }],
+    includesSpecimens: [{ occurrenceID: 'urn:catalog:::MVZ225749' }],
+  };
+  const tunit3 = {
+    includesSpecimens: [{ catalogNumber: 'MVZ225749' }],
+    externalReferences: ['http://arctos.database.museum/guid/MVZ:Herp:225749'],
+  };
+  const tunit4 = {
+    externalReferences: ['http://arctos.database.museum/guid/MVZ:Herp:225749'],
+  };
+
+  describe('#matchByBinomialName', function () {
+    it('should be able to match tunit1 and tunit2 by binomial name', function () {
+      expect(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchByExternalReferences()).to.be.false;
+      expect(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchBySpecimenIdentifier()).to.be.false;
+      expect(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchByBinomialName()).to.be.true;
+    });
+  });
+  describe('#matchByExternalReferences', function () {
+    it('should be able to match tunit3 and tunit4 by external references', function () {
+      expect(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchByExternalReferences()).to.be.true;
+      expect(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchBySpecimenIdentifier()).to.be.false;
+      expect(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchByBinomialName()).to.be.false;
+    });
+  });
+  describe('#matchBySpecimenIdentifier', function () {
+    it('should be able to match tunit2 and tunit3 by specimen identifiers', function () {
+      expect(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchByExternalReferences()).to.be.false;
+      expect(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchBySpecimenIdentifier()).to.be.true;
+      expect(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchByBinomialName()).to.be.false;
+    });
+  });
+  describe('#matched and #matchReason', function () {
+    it('should match tunit1 and tunit2 on the basis of identical binomial name', function () {
+      const matcher = new phyx.TaxonomicUnitMatcher(tunit1, tunit2);
+      expect(matcher.matched).to.be.true;
+      expect(matcher.matchReason).to.include('share the same binomial name');
+    });
+
+    it('should match tunit3 and tunit4 by identical external reference', function () {
+      const matcher = new phyx.TaxonomicUnitMatcher(tunit3, tunit4);
+      expect(matcher.matched).to.be.true;
+      expect(matcher.matchReason).to.include('External reference');
+    });
+
+    it('should match tunit2 and tunit3 by identical specimen identifier', function () {
+      const matcher = new phyx.TaxonomicUnitMatcher(tunit2, tunit3);
+      expect(matcher.matched).to.be.true;
+      expect(matcher.matchReason).to.include('Specimen identifier');
+    });
+  });
+});


### PR DESCRIPTION
This is a copy of the phyx.js code in the [Curation Tool repository at 14d2c3d5d1](https://github.com/phyloref/curation-tool/commit/14d2c3d5d12ee4e925e29961bd46587aabfb8cd4), with some basic modifications to remove the dependency on phylotree.js and to ensure that it works with the [new Curation Tool](https://github.com/phyloref/curation-tool/pull/136). Once this PR has been merged, I'll publish this to npm as phyx.js 0.0.1.

I considered starting by extracting the full history of phyx.js from the Curation Tool repository, but the commit messages on those commits related largely to other parts of the Curation Tool rather than this library itself, so that history would be more likely to be confusing than useful. I therefore opted to extract the latest version of this code and build on that.

This includes some code that has since been moved into the [new Curation Tool](https://github.com/phyloref/curation-tool/pull/136); future PRs will likely remove a lot of unnecessary code from this package in order to focus it down on its core purpose.