### PR TITLE
Add Newick parser to phyx.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this library will be documented in this file.
 The format is based on [Keep a Changelog] and this project adheres to [Semantic Versioning].
 
 ## Unreleased
+
+## 0.1.1 - 2019-02-06
 ### Added
 - A replacement for the Phylotree.js Newick parser.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this library will be documented in this file.
 
 The format is based on [Keep a Changelog] and this project adheres to [Semantic Versioning].
 
+## Unreleased
+### Added
+- A replacement for the Phylotree.js Newick parser.
+
 ## 0.1.0 - 2019-01-27
 ### Added
 - Transfered initial code from the [Phyloreference Curation Tool]. The initial

--- a/index.js
+++ b/index.js
@@ -806,12 +806,16 @@ class PhylogenyWrapper {
       if (!hasOwnProperty(parent, 'children')) parent.children = [];
       parent.children.push(child);
 
+      // Phylotree.js uses 'name' instead of 'label'.
+      if (hasOwnProperty(parent, 'label')) { parent.name = parent.label; }
+      if (hasOwnProperty(child, 'label')) { child.name = child.label; }
+
       // Phylotree.js uses 'attribute' to store weights, so we'll store it there as well.
-      if (!hasOwnProperty(child, 'attribute') && weight !== 0) child.attribute = weight;
+      if (!hasOwnProperty(child, 'attribute') && !Number.isNaN(weight)) child.attribute = weight;
     });
 
     // Set root 'attribute' to root weight.
-    if (!hasOwnProperty(root, 'attribute') && rootWeight !== 0) root.attribute = rootWeight;
+    if (!hasOwnProperty(root, 'attribute') && !Number.isNaN(rootWeight)) root.attribute = rootWeight;
 
     return { json: root };
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phyloref/phyx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Phyloreference Exchange (PHYX) library in JavaScript",
   "main": "index.js",
   "scripts": {

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -236,4 +236,46 @@ describe('PhylogenyWrapper', function () {
       });
     });
   });
+
+  describe('#getParsedNewickWithIRIs', function () {
+    const tests = [
+      {
+        newick: '(((A, B)C, D)E, F)G',
+        result: {
+          json: {
+            '@id': '_node0',
+            name: 'G',
+            label: 'G',
+            children: [
+              { '@id': '_node1', name: 'F', label: 'F' },
+              {
+                '@id': '_node2',
+                name: 'E',
+                label: 'E',
+                children: [
+                  { '@id': '_node3', name: 'D', label: 'D' },
+                  {
+                    '@id': '_node4',
+                    name: 'C',
+                    label: 'C',
+                    children: [
+                      { '@id': '_node5', name: 'B', label: 'B' },
+                      { '@id': '_node6', name: 'A', label: 'A' },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    tests.forEach((test) => {
+      it('should be able to parse a provided Newick string as expected', function () {
+        expect(new phyx.PhylogenyWrapper({ newick: test.newick }).getParsedNewickWithIRIs(''))
+          .to.deep.equal(test.result);
+      });
+    });
+  });
 });


### PR DESCRIPTION
We previously used the Newick parser that was included with [phylotree.js](http://phylotree.hyphy.org/), but accessing this parser requires some complicated setup as it installs itself into d3 rather than exposing classes and methods for general use. This PR provides an alternate parser that parses the Newick using [newick-js](https://www.npmjs.com/package/newick-js), and then converts it into the format produced by Phylotree.js. It also includes a test for this package. Phylotree's Newick parser may still be used instead if needed.