### PR TITLE
Updated OWL equivalent class expression generation to Model 2.0

### DIFF
--- a/docs/context/v0.2.0/phyx.json
+++ b/docs/context/v0.2.0/phyx.json
@@ -2,6 +2,8 @@
     "@context": [{
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     }, {
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    }, {
         "_comments": {
           "@id": "rdfs:comment",
           "_comments": "TOP-LEVEL DOCUMENT PROPERTIES"

--- a/docs/context/v0.2.0/phyx.json
+++ b/docs/context/v0.2.0/phyx.json
@@ -112,12 +112,12 @@
         },
 
         "newick": {
-            "@id": "testcase:as_newick_string",
+            "@id": "phyloref:newick_expression",
             "@type": "xsd:string"
         },
 
         "cladeDefinition": {
-            "@id": "testcase:clade_definition",
+            "@id": "obo:IAO_0000115",
             "@type": "xsd:string"
         }
     }, {

--- a/docs/context/v0.2.0/phyx.json
+++ b/docs/context/v0.2.0/phyx.json
@@ -48,6 +48,11 @@
             "@type": "@id"
         },
 
+        "parent": {
+            "@id": "obo:CDAO_0000179",
+            "type": "@id"
+        },
+
         "hasRootNode": {
             "@id": "testcase:has_root_node",
             "@type": "@id"

--- a/docs/context/v0.2.0/phyx.json
+++ b/docs/context/v0.2.0/phyx.json
@@ -1,0 +1,306 @@
+{
+    "@context": [{
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    }, {
+        "_comments": {
+          "@id": "rdfs:comment",
+          "_comments": "TOP-LEVEL DOCUMENT PROPERTIES"
+        },
+
+        "ot": "http://purl.org/opentree/nexson#",
+
+        "curator": {
+            "@id": "ot:curatorName",
+            "@type": "xsd:string"
+        },
+
+        "comments": {
+            "@id": "ot:comment",
+            "@type": "xsd:string"
+        },
+
+        "citation": "ot:studyPublicationReference",
+
+        "url": {
+            "@id": "ot:studyPublication",
+            "@type": "@id"
+        },
+
+        "year": {
+            "@id": "ot:studyYear",
+            "@type": "xsd:integer"
+        }
+    }, {
+        "_comments": {
+          "@id": "rdfs:comment",
+          "_comments": "Management of nodes and internode relationships"
+        },
+
+        "testcase": "http://vocab.phyloref.org/phyloref/testcase.owl#",
+
+        "nodes": {
+            "@id": "testcase:has_node",
+            "@container": "@set"
+        },
+
+        "inPhylogeny": {
+            "@id": "testcase:in_phylogeny",
+            "@type": "@id"
+        },
+
+        "hasRootNode": {
+            "@id": "testcase:has_root_node",
+            "@type": "@id"
+        },
+
+        "phylogenies": {
+            "@id": "testcase:has_phylogeny",
+            "@container": "@set"
+        }
+    }, {
+        "_comments": {
+          "@id": "rdfs:comment",
+          "_comments": "CDAO and Phyloref properties"
+        },
+
+        "obo": "http://purl.obolibrary.org/obo/",
+        "phyloref": "http://ontology.phyloref.org/phyloref.owl#",
+
+        "children": {
+            "@id": "obo:CDAO_0000149",
+            "@type": "@id"
+        },
+
+        "siblings": {
+            "@id": "phyloref:has_Sibling",
+            "@type": "@id"
+        },
+
+        "phylorefs": {
+            "@id": "testcase:has_phyloreference",
+            "@container": "@set"
+        },
+
+        "malformedPhyloreference": {
+            "@id": "testcase:malformed_phyloreference",
+            "@type": "xsd:string"
+        },
+
+        "hasSpecifier": {
+            "@id": "testcase:has_specifier",
+            "@container": "@set"
+        },
+
+        "hasInternalSpecifier": {
+            "@id": "testcase:has_internal_specifier",
+            "@container": "@set"
+        },
+
+        "hasExternalSpecifier": {
+            "@id": "testcase:has_external_specifier",
+            "@container": "@set"
+        },
+
+        "hasUnmatchedSpecifiers": {
+            "@id": "testcase:has_unmatched_specifier",
+            "@container": "@set"
+        },
+
+        "hasAdditionalClass": {
+            "@id": "testcase:has_additional_class",
+            "@container": "@set"
+        },
+
+        "newick": {
+            "@id": "testcase:as_newick_string",
+            "@type": "xsd:string"
+        },
+
+        "cladeDefinition": {
+            "@id": "testcase:clade_definition",
+            "@type": "xsd:string"
+        }
+    }, {
+        "_comments": {
+          "@id": "rdfs:comment",
+          "_comments": "LOW-LEVEL RDF/RDFS/OWL TERMS"
+        },
+
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+
+        "label": {
+            "@id": "rdfs:label",
+            "@type": "xsd:string"
+        },
+
+        "labels": {
+            "@id": "rdfs:label",
+            "@type": "xsd:string",
+            "@container": "@set"
+        },
+
+        "comment": {
+            "@id": "rdfs:comment",
+            "@type": "xsd:string"
+        }
+    }, {
+        "_comments": {
+          "@id": "rdfs:comment",
+          "_comments": "GLUE TO RENDER ONTOLOGY IN RDF"
+        },
+
+        "owl": "http://www.w3.org/2002/07/owl#",
+
+        "owl:imports": {
+            "@id": "owl:imports",
+            "@type": "@id"
+        },
+
+        "equivalentClass": "owl:equivalentClass",
+        "intersectionOf": {
+            "@id": "owl:intersectionOf",
+            "@container": "@list"
+        },
+        "onProperty": {
+            "@id": "owl:onProperty",
+            "@type": "@id"
+        },
+        "someValuesFrom": {
+            "@id": "owl:someValuesFrom",
+            "@container": "@set"
+        },
+        "unionOf": {
+            "@id": "owl:unionOf",
+            "@container": "@list"
+        },
+        "hasValue": {
+            "@id": "owl:hasValue",
+            "@type": "xsd:string"
+        },
+
+        "filename": "testcase:filename",
+
+        "externalReferences": {
+            "@id": "obo:CDAO_0000164",
+            "@container": "@set"
+        },
+
+        "scientificNames": {
+            "@id": "testcase:has_scientific_name",
+            "@container": "@set"
+        },
+
+        "includesSpecimens": {
+            "@id": "testcase:includes_specimen",
+            "@container": "@set"
+        }
+    }, {
+        "_comments": {
+          "@id": "rdfs:comment",
+          "_comments": "Properties of individual TUs: scientific name and specimens"
+        },
+
+        "dwc": "http://rs.tdwg.org/dwc/terms/",
+
+        "scientificName": {
+            "@id": "dwc:scientificName",
+            "@type": "xsd:string"
+        },
+        "binomialName": {
+            "@id": "testcase:has_binomial_name",
+            "@type": "xsd:string"
+        },
+        "genus": {
+            "@id": "dwc:genus",
+            "@type": "xsd:string"
+        },
+        "specificEpithet": {
+            "@id": "dwc:specificEpithet",
+            "@type": "xsd:string"
+        },
+
+        "occurrenceID": "dwc:occurrenceID",
+        "catalogNumber": "dwc:catalogNumber",
+        "collectionCode": "dwc:collectionCode",
+        "institutionCode": "dwc:institutionCode",
+
+        "subClassOf": {
+            "@id": "rdfs:subClassOf",
+            "@type": "@id"
+        },
+
+        "expectedPhyloreferenceNamed": "testcase:expected_phyloreference_named",
+
+        "reason": {
+            "@id": "testcase:reason_for_match",
+            "@type": "xsd:string"
+        },
+
+        "hasTaxonomicUnitMatches": {
+            "@id": "testcase:has_taxonomic_unit_match",
+            "@container": "@set"
+        },
+
+        "referencesTaxonomicUnits": {
+            "@id": "testcase:references_taxonomic_unit",
+            "domain": "Specifier",
+            "range": "TU",
+            "@container": "@set"
+        },
+
+        "matchesTaxonomicUnits": {
+            "@id": "testcase:matches_taxonomic_unit",
+            "domain": "TUMatch",
+            "range": "TU",
+            "@container": "@set"
+        },
+
+        "representsTaxonomicUnits": {
+            "@id": "obo:CDAO_0000187",
+            "domain": "Node",
+            "range": "TU",
+            "@container": "@set"
+        },
+
+        "specifierWillNotMatch": {
+            "@id": "testcase:specifier_will_not_match",
+            "@container": "@set"
+        }
+    }, {
+        "_comments": {
+          "@id": "rdfs:comment",
+          "_comments": "TERMS FROM THE ANNOTATION ONTOLOGY"
+        },
+
+        "oa": "http://www.w3.org/ns/oa#",
+
+        "annotations": {
+            "@id": "testcase:has_annotation",
+            "@container": "@set"
+        },
+
+        "annotationTarget": {
+            "@id": "oa:hasTarget",
+            "@type": "@id"
+        },
+
+        "annotationName": {
+            "@id": "rdfs:label",
+            "@type": "xsd:string"
+        },
+
+        "annotationBody": {
+            "@id": "oa:hasBody",
+            "@type": "xsd:string"
+        }
+    }, {
+        "_comments": {
+          "@id": "rdfs:comment",
+          "_comments": "TERMS FROM THE PUBLISHING STATUS ONTOLOGY AND RELATED"
+        },
+
+        "pso": "http://purl.org/spar/pso/",
+        "tvc": "http://www.essepuntato.it/2012/04/tvc/",
+        "timeinterval": "http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#"
+    }]
+}

--- a/docs/context/v0.2.0/phyx.json
+++ b/docs/context/v0.2.0/phyx.json
@@ -48,9 +48,11 @@
             "@type": "@id"
         },
 
+        "obo": "http://purl.obolibrary.org/obo/",
+
         "parent": {
             "@id": "obo:CDAO_0000179",
-            "type": "@id"
+            "@type": "@id"
         },
 
         "hasRootNode": {
@@ -91,18 +93,13 @@
             "@type": "xsd:string"
         },
 
-        "hasSpecifier": {
-            "@id": "testcase:has_specifier",
+        "internalSpecifiers": {
+            "@id": "testcase:internal_specifier",
             "@container": "@set"
         },
 
-        "hasInternalSpecifier": {
-            "@id": "testcase:has_internal_specifier",
-            "@container": "@set"
-        },
-
-        "hasExternalSpecifier": {
-            "@id": "testcase:has_external_specifier",
+        "externalSpecifiers": {
+            "@id": "testcase:external_specifier",
             "@container": "@set"
         },
 
@@ -203,6 +200,26 @@
         "_comments": {
           "@id": "rdfs:comment",
           "_comments": "Properties of individual TUs: scientific name and specimens"
+        },
+
+        "hasName": {
+          "@id": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"
+        },
+
+        "nameComplete": {
+          "@id": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+          "@type": "xsd:string"
+        },
+
+        "nameString": {
+          "@id": "http://rs.tdwg.org/ontology/voc/TaxonName#nameString",
+          "@type": "xsd:string"
+        },
+
+        "nomenclaturalCode": {
+          "@id": "http://rs.tdwg.org/ontology/voc/TaxonName#nomenclaturalCode",
+          "@type": "@id"
         },
 
         "dwc": "http://rs.tdwg.org/dwc/terms/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,7 +1260,9 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "optional": true
     },
     "external-editor": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/phyloref/phyx.js#readme",
   "dependencies": {
-    "extend": "^3.0.2",
     "lodash": "^4.17.11",
     "moment": "^2.23.0",
     "newick-js": "^1.1.0"

--- a/src/utils/owlterms.js
+++ b/src/utils/owlterms.js
@@ -22,6 +22,7 @@ module.exports = {
 
   // Terms from Darwin Core.
   DWC_OCCURRENCE: 'http://rs.tdwg.org/dwc/terms/Occurrence',
+  DWC_OCCURRENCE_ID: 'http://rs.tdwg.org/dwc/terms/occurrenceID',
 
   // Nomenclatural codes from Nomen.
   NAME_IN_UNKNOWN_CODE: 'http://purl.obolibrary.org/obo/NOMEN_0000036', // NOMEN:scientific name

--- a/src/utils/owlterms.js
+++ b/src/utils/owlterms.js
@@ -1,8 +1,10 @@
 
 // Some OWL constants to be used.
 module.exports = {
-  CDAO_HAS_CHILD: 'obo:CDAO_0000149',
-  CDAO_HAS_DESCENDANT: 'obo:CDAO_0000174',
+  // Where is our context file located?
+  PHYX_CONTEXT_JSON: 'http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json',
+
+  // Phyloref properties.
   PHYLOREF_EXCLUDES_LINEAGE_TO: 'phyloref:excludes_lineage_to',
   PHYLOREFERENCE_TEST_CASE: 'testcase:PhyloreferenceTestCase',
   PHYLOREFERENCE_PHYLOGENY: 'testcase:PhyloreferenceTestPhylogeny',
@@ -10,8 +12,15 @@ module.exports = {
   TU_HAS_NAME_PROP: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
   TU_SPECIMEN_PROP: 'dwc:organismID',
 
+  // Terms from RDF
+  RDF_TYPE: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+
   // Terms from CDAO (http://www.obofoundry.org/ontology/cdao.html).
-  CDAO_TU: 'http://purl.obolibrary.org/obo/CDAO_0000138',
+  CDAO_TU: 'obo:CDAO_0000138',
+  CDAO_NODE: 'obo:CDAO_0000140',
+  CDAO_REPRESENTS_TU: 'obo:CDAO_0000187',
+  CDAO_HAS_CHILD: 'obo:CDAO_0000149',
+  CDAO_HAS_DESCENDANT: 'obo:CDAO_0000174',
 
   // Terms from the TaxonName ontology
   // (https://github.com/tdwg/ontology/blob/master/ontology/voc/TaxonName.rdf).

--- a/src/utils/owlterms.js
+++ b/src/utils/owlterms.js
@@ -4,6 +4,9 @@ module.exports = {
   // Where is our context file located?
   PHYX_CONTEXT_JSON: 'http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json',
 
+  // OWL properties.
+  OWL_RESTRICTION: 'owl:Restriction',
+
   // Phyloref properties.
   PHYLOREF_EXCLUDES_LINEAGE_TO: 'phyloref:excludes_lineage_to',
   PHYLOREFERENCE_TEST_CASE: 'testcase:PhyloreferenceTestCase',

--- a/src/utils/owlterms.js
+++ b/src/utils/owlterms.js
@@ -17,6 +17,7 @@ module.exports = {
   // (https://github.com/tdwg/ontology/blob/master/ontology/voc/TaxonName.rdf).
   TDWG_VOC_TAXON_NAME: 'http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName',
   TDWG_VOC_TAXON_CONCEPT: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept',
+  TDWG_VOC_HAS_NAME: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
   TDWG_VOC_NAME_COMPLETE: 'http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete',
 
   // Terms from Darwin Core.

--- a/src/utils/owlterms.js
+++ b/src/utils/owlterms.js
@@ -13,7 +13,7 @@ module.exports = {
   TU_SPECIMEN_PROP: 'dwc:organismID',
 
   // Terms from RDF
-  RDF_TYPE: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+  RDF_TYPE: 'rdf:type',
 
   // Terms from CDAO (http://www.obofoundry.org/ontology/cdao.html).
   CDAO_TU: 'obo:CDAO_0000138',

--- a/src/utils/owlterms.js
+++ b/src/utils/owlterms.js
@@ -5,9 +5,12 @@ module.exports = {
   PHYX_CONTEXT_JSON: 'http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json',
 
   // OWL properties.
+  OWL_CLASS: 'owl:Class',
   OWL_RESTRICTION: 'owl:Restriction',
 
   // Phyloref properties.
+  PHYLOREF_INCLUDES_TU: 'phyloref:includes_TU',
+  PHYLOREF_EXCLUDES_TU: 'phyloref:excludes_TU',
   PHYLOREF_EXCLUDES_LINEAGE_TO: 'phyloref:excludes_lineage_to',
   PHYLOREFERENCE_TEST_CASE: 'testcase:PhyloreferenceTestCase',
   PHYLOREFERENCE_PHYLOGENY: 'testcase:PhyloreferenceTestPhylogeny',

--- a/src/wrappers/PhylogenyWrapper.js
+++ b/src/wrappers/PhylogenyWrapper.js
@@ -344,7 +344,7 @@ class PhylogenyWrapper {
             const wrappedTUnit = new TaxonomicUnitWrapper(tu);
 
             if (wrappedTUnit) {
-              const equivClass = wrappedTUnit.asEquivClass;
+              const equivClass = wrappedTUnit.asOWLEquivClass;
               if (equivClass) {
                 nodeAsJSONLD[owlterms.RDF_TYPE].push(
                   {

--- a/src/wrappers/PhylogenyWrapper.js
+++ b/src/wrappers/PhylogenyWrapper.js
@@ -216,7 +216,9 @@ class PhylogenyWrapper {
     //
     // Note that old-style taxonomic units were lists while new-style taxonomic
     // units are single objects. So we turn it into a single entry list here.
-    return [TaxonomicUnitWrapper.fromLabel(nodeLabel.trim())];
+    const tunit = TaxonomicUnitWrapper.fromLabel(nodeLabel.trim());
+    if (tunit) return [tunit];
+    return []; // No TUnit? Return the empty list.
   }
 
   getNodeLabelsMatchedBySpecifier(specifier) {

--- a/src/wrappers/PhylogenyWrapper.js
+++ b/src/wrappers/PhylogenyWrapper.js
@@ -225,11 +225,6 @@ class PhylogenyWrapper {
     // Return a list of node labels matched by a given specifier on
     // a given phylogeny.
 
-    // Does the specifier have any taxonomic units? If not, we can't
-    // match anything!
-    if (!has(specifier, 'referencesTaxonomicUnits')) { return []; }
-    const specifierTUnits = specifier.referencesTaxonomicUnits;
-
     return this.getNodeLabels().filter((nodeLabel) => {
       // Find all the taxonomic units associated with the specifier and
       // with the node.
@@ -237,10 +232,8 @@ class PhylogenyWrapper {
 
       // Attempt pairwise matches between taxonomic units in the specifier
       // and associated with the node.
-      return specifierTUnits.some(
-        tunit1 => nodeTUnits.some(
-          tunit2 => new TaxonomicUnitMatcher(tunit1, tunit2).matched
-        )
+      return nodeTUnits.some(
+        tunit => new TaxonomicUnitMatcher(specifier, tunit).matched
       );
     });
   }
@@ -353,7 +346,7 @@ class PhylogenyWrapper {
             const wrappedTUnit = new TaxonomicUnitWrapper(tu);
 
             if (wrappedTUnit) {
-              const equivClass = wrappedTUnit.asEquivClass();
+              const equivClass = wrappedTUnit.asEquivClass;
               if (equivClass) {
                 nodeAsJSONLD['http://www.w3.org/1999/02/22-rdf-syntax-ns#type'].push(
                   {

--- a/src/wrappers/PhylogenyWrapper.js
+++ b/src/wrappers/PhylogenyWrapper.js
@@ -322,9 +322,7 @@ class PhylogenyWrapper {
         // can't support @type being an array (despite that being in the standard,
         // see https://w3c.github.io/json-ld-syntax/#example-14-specifying-multiple-types-for-a-node),
         // so we fall back to using rdf:type instead.
-        nodeAsJSONLD['http://www.w3.org/1999/02/22-rdf-syntax-ns#type'] = [
-          'http://purl.obolibrary.org/obo/CDAO_0000140', // CDAO:Node
-        ];
+        nodeAsJSONLD[owlterms.RDF_TYPE] = [owlterms.CDAO_NODE];
 
         // Add labels, additional node properties and taxonomic units.
         if (has(node, 'name') && node.name !== '') {
@@ -348,10 +346,10 @@ class PhylogenyWrapper {
             if (wrappedTUnit) {
               const equivClass = wrappedTUnit.asEquivClass;
               if (equivClass) {
-                nodeAsJSONLD['http://www.w3.org/1999/02/22-rdf-syntax-ns#type'].push(
+                nodeAsJSONLD[owlterms.RDF_TYPE].push(
                   {
                     '@type': 'owl:Restriction',
-                    onProperty: 'obo:CDAO_0000187',
+                    onProperty: owlterms.CDAO_REPRESENTS_TU,
                     someValuesFrom: equivClass,
                   }
                 );

--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -111,35 +111,6 @@ class PhylorefWrapper {
     if (index !== -1) this.phyloref.externalSpecifiers.splice(index, 1);
   }
 
-  static getSpecifierLabel(specifier) {
-    // Try to determine the label of a specifier. This checks the
-    // 'label' and 'description' properties, and then tries to create a
-    // descriptive label by using the list of referenced taxonomic units.
-    //
-    // This logically belongs in PhylorefWrapper, but we don't actually need to
-    // know the phyloreference to figure out the specifier label, which is why
-    // this is a static method.
-
-    // Is this specifier even non-null?
-    if (specifier === undefined) return undefined;
-    if (specifier === null) return undefined;
-
-    // Maybe there is a label or description right there?
-    if (has(specifier, 'label')) return specifier.label;
-    if (has(specifier, 'description')) return specifier.description;
-
-    // Look at the individual taxonomic units.
-    if (has(specifier, 'referencesTaxonomicUnits')) {
-      const labels = specifier.referencesTaxonomicUnits
-        .map(tu => new TaxonomicUnitWrapper(tu).label)
-        .filter(label => (label !== undefined));
-      if (labels.length > 0) return labels.join('; ');
-    }
-
-    // No idea!
-    return undefined;
-  }
-
   getExpectedNodeLabels(phylogeny) {
     // Given a phylogeny, determine which node labels we expect this phyloref to
     // resolve to. To do this, we:
@@ -378,7 +349,7 @@ class PhylorefWrapper {
     return {
       '@type': 'owl:Restriction',
       onProperty: 'phyloref:includes_TU',
-      someValuesFrom: new TaxonomicUnitWrapper(tu).asEquivClass(),
+      someValuesFrom: new TaxonomicUnitWrapper(tu).asEquivClass,
     };
   }
 
@@ -396,7 +367,7 @@ class PhylorefWrapper {
           {
             '@type': 'owl:Restriction',
             onProperty: 'phyloref:excludes_TU',
-            someValuesFrom: new TaxonomicUnitWrapper(tu1).asEquivClass(),
+            someValuesFrom: new TaxonomicUnitWrapper(tu1).asEquivClass,
           },
           PhylorefWrapper.getIncludesRestrictionForTU(tu2),
         ],
@@ -539,7 +510,7 @@ class PhylorefWrapper {
         {
           '@type': 'owl:Restriction',
           onProperty: 'phyloref:excludes_TU',
-          someValuesFrom: new TaxonomicUnitWrapper(tu).asEquivClass(),
+          someValuesFrom: new TaxonomicUnitWrapper(tu).asEquivClass,
         },
       ],
     }];
@@ -558,7 +529,7 @@ class PhylorefWrapper {
             someValuesFrom: {
               '@type': 'owl:Restriction',
               onProperty: 'phyloref:excludes_TU',
-              someValuesFrom: new TaxonomicUnitWrapper(tu).asEquivClass(),
+              someValuesFrom: new TaxonomicUnitWrapper(tu).asEquivClass,
             },
           },
         ],

--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -346,7 +346,7 @@ class PhylorefWrapper {
       additionalClassLabel += ` ~ ${externalSpecifierLabel})`;
     }
 
-    process.stderr.write(`Additional class label: ${additionalClassLabel}\n`);
+    // process.stderr.write(`Additional class label: ${additionalClassLabel}\n`);
 
     // TODO We need to replace this with an actual object-based comparison,
     // rather than trusting the labels to tell us everything.
@@ -662,11 +662,15 @@ class PhylorefWrapper {
     phylorefAsJSONLD.subClassOf = 'phyloref:Phyloreference';
 
     // Construct an equivalentClass expression for this phyloreference.
-    const internalSpecifiers = this.phyloref.internalSpecifiers || [];
-    const externalSpecifiers = this.phyloref.externalSpecifiers || [];
+    const internalSpecifiers = phylorefAsJSONLD.internalSpecifiers || [];
+    const externalSpecifiers = phylorefAsJSONLD.externalSpecifiers || [];
 
     // We might need to make additional JSON-LD.
+    // So we reset our additional class counts and records.
+    PhylorefWrapper.additionalClassCount = 0;
+    PhylorefWrapper.additionalClassesByLabel = {};
     phylorefAsJSONLD.hasAdditionalClass = [];
+
     if (internalSpecifiers.length === 0) {
       // We can't handle phyloreferences without at least one internal specifier.
       phylorefAsJSONLD.malformedPhyloreference = 'No internal specifiers provided';
@@ -700,10 +704,6 @@ class PhylorefWrapper {
     return phylorefAsJSONLD;
   }
 }
-
-/** Keep track of additional classes across all instances. */
-PhylorefWrapper.additionalClassCount = 0;
-PhylorefWrapper.additionalClassesByLabel = {};
 
 module.exports = {
   PhylorefWrapper,

--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -349,7 +349,7 @@ class PhylorefWrapper {
     return {
       '@type': 'owl:Restriction',
       onProperty: 'phyloref:includes_TU',
-      someValuesFrom: new TaxonomicUnitWrapper(tu).asEquivClass,
+      someValuesFrom: new TaxonomicUnitWrapper(tu).asOWLEquivClass,
     };
   }
 
@@ -367,7 +367,7 @@ class PhylorefWrapper {
           {
             '@type': 'owl:Restriction',
             onProperty: 'phyloref:excludes_TU',
-            someValuesFrom: new TaxonomicUnitWrapper(tu1).asEquivClass,
+            someValuesFrom: new TaxonomicUnitWrapper(tu1).asOWLEquivClass,
           },
           PhylorefWrapper.getIncludesRestrictionForTU(tu2),
         ],
@@ -510,7 +510,7 @@ class PhylorefWrapper {
         {
           '@type': 'owl:Restriction',
           onProperty: 'phyloref:excludes_TU',
-          someValuesFrom: new TaxonomicUnitWrapper(tu).asEquivClass,
+          someValuesFrom: new TaxonomicUnitWrapper(tu).asOWLEquivClass,
         },
       ],
     }];
@@ -529,7 +529,7 @@ class PhylorefWrapper {
             someValuesFrom: {
               '@type': 'owl:Restriction',
               onProperty: 'phyloref:excludes_TU',
-              someValuesFrom: new TaxonomicUnitWrapper(tu).asEquivClass,
+              someValuesFrom: new TaxonomicUnitWrapper(tu).asOWLEquivClass,
             },
           },
         ],

--- a/src/wrappers/PhyxWrapper.js
+++ b/src/wrappers/PhyxWrapper.js
@@ -1,6 +1,5 @@
 /** Used to make deep copies of objects. */
-const extend = require('extend');
-const { has } = require('lodash');
+const { has, cloneDeep } = require('lodash');
 
 const owlterms = require('../utils/owlterms');
 
@@ -57,7 +56,7 @@ class PhyxWrapper {
     //  2. We have to convert phylogenies into OWL restrictions.
     //  3. Insert all matches between taxonomic units in this file.
     //
-    const jsonld = extend(true, {}, this.phyx);
+    const jsonld = cloneDeep(this.phyx);
 
     // Add descriptions for individual nodes in each phylogeny.
     if (has(jsonld, 'phylogenies')) {

--- a/src/wrappers/PhyxWrapper.js
+++ b/src/wrappers/PhyxWrapper.js
@@ -141,7 +141,7 @@ class PhyxWrapper {
 
     // If the '@context' is missing, add it here.
     if (!has(jsonld, '@context')) {
-      jsonld['@context'] = 'http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json';
+      jsonld['@context'] = owlterms.PHYX_CONTEXT_JSON;
     }
 
     return jsonld;

--- a/src/wrappers/PhyxWrapper.js
+++ b/src/wrappers/PhyxWrapper.js
@@ -136,16 +136,13 @@ class PhyxWrapper {
     jsonld['@type'] = [owlterms.PHYLOREFERENCE_TEST_CASE, 'owl:Ontology'];
     jsonld['owl:imports'] = [
       'http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl',
-      // - Will become 'http://vocab.phyloref.org/phyloref/testcase.owl'
-      'http://ontology.phyloref.org/2018-12-04/phyloref.owl',
-      // - The Phyloreferencing ontology.
-      'http://purl.obolibrary.org/obo/bco.owl',
-      // - Contains OWL definitions for Darwin Core terms
+      'http://ontology.phyloref.org/2018-12-14/phyloref.owl',
+      'http://ontology.phyloref.org/2018-12-14/tcan.owl',
     ];
 
     // If the '@context' is missing, add it here.
     if (!has(jsonld, '@context')) {
-      jsonld['@context'] = 'http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json';
+      jsonld['@context'] = 'http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json';
     }
 
     return jsonld;

--- a/src/wrappers/SpecimenWrapper.js
+++ b/src/wrappers/SpecimenWrapper.js
@@ -181,6 +181,22 @@ class SpecimenWrapper {
     // Return a label for this specimen.
     return `Specimen ${this.occurrenceID}`;
   }
+
+  /** Return this specimen as an equivalentClass expression. */
+  get asEquivClass() {
+    // We can't do anything without an occurrence ID!
+    if (!this.occurrenceID) return undefined;
+
+    // TODO: Should we also match by this.taxonConcept is one is available?
+    // Technically no, but it might be useful. Hmm.
+
+    // Return as an OWL restriction.
+    return {
+      '@type': 'owl:Restriction',
+      onProperty: owlterms.DWC_OCCURRENCE_ID,
+      hasValue: this.occurrenceID,
+    };
+  }
 }
 
 module.exports = {

--- a/src/wrappers/SpecimenWrapper.js
+++ b/src/wrappers/SpecimenWrapper.js
@@ -183,7 +183,7 @@ class SpecimenWrapper {
   }
 
   /** Return this specimen as an equivalentClass expression. */
-  get asEquivClass() {
+  get asOWLEquivClass() {
     // We can't do anything without an occurrence ID!
     if (!this.occurrenceID) return undefined;
 

--- a/src/wrappers/TaxonConceptWrapper.js
+++ b/src/wrappers/TaxonConceptWrapper.js
@@ -154,7 +154,7 @@ class TaxonConceptWrapper {
    * Note that we don't include the accordingTo information in this
    * query, since we don't have a useful way to use that during OWL reasoning.
    */
-  asOWLEquivClass() {
+  get asOWLEquivClass() {
     // Without a taxonomicName, we can't do anything.
     if (!this.taxonName) return undefined;
 

--- a/src/wrappers/TaxonConceptWrapper.js
+++ b/src/wrappers/TaxonConceptWrapper.js
@@ -160,7 +160,7 @@ class TaxonConceptWrapper {
 
     return {
       '@type': 'owl:Restriction',
-      onProperty: 'hasName',
+      onProperty: owlterms.TDWG_VOC_HAS_NAME,
       someValuesFrom: new TaxonNameWrapper(this.taxonName).asOWLEquivClass(),
     };
   }

--- a/src/wrappers/TaxonConceptWrapper.js
+++ b/src/wrappers/TaxonConceptWrapper.js
@@ -161,7 +161,7 @@ class TaxonConceptWrapper {
     return {
       '@type': 'owl:Restriction',
       onProperty: owlterms.TDWG_VOC_HAS_NAME,
-      someValuesFrom: new TaxonNameWrapper(this.taxonName).asOWLEquivClass(),
+      someValuesFrom: new TaxonNameWrapper(this.taxonName).asOWLEquivClass,
     };
   }
 }

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -18,6 +18,7 @@ class TaxonNameWrapper {
    * a taxon name.
    */
   constructor(txname) {
+    if (txname === undefined) throw new Error('TaxonNameWrapper tried to wrap undefined');
     this.txname = txname;
   }
 

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -196,7 +196,7 @@ class TaxonNameWrapper {
   /**
    * Return this taxon name as an OWL equivalentClass expression.
    */
-  asOWLEquivClass() {
+  get asOWLEquivClass() {
     // No complete name, can't return anything.
     if (!this.nameComplete) return undefined;
 

--- a/src/wrappers/TaxonomicUnitWrapper.js
+++ b/src/wrappers/TaxonomicUnitWrapper.js
@@ -200,7 +200,7 @@ class TaxonomicUnitWrapper {
   /**
    * Return this taxonomic unit as an OWL/JSON-LD object.
    */
-  asJSONLD() {
+  get asJSONLD() {
     const jsonld = cloneDeep(this.tunit);
 
     // Add CDAO_TU as a type to the existing types.
@@ -208,7 +208,7 @@ class TaxonomicUnitWrapper {
       if (isArray(this.tunit['@type'])) this.tunit['@type'].push(owlterms.CDAO_TU);
     }
 
-    const equivClass = this.asEquivClass();
+    const equivClass = this.asEquivClass;
     if (equivClass) {
       jsonld.equivalentClass = equivClass;
     }
@@ -219,13 +219,13 @@ class TaxonomicUnitWrapper {
   /**
    * Return the equivalent class expression for this taxonomic unit.
    */
-  asEquivClass() {
+  get asEquivClass() {
     if (this.types.includes(TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT)) {
-      return new TaxonConceptWrapper(this.tunit).asEquivClass();
+      return new TaxonConceptWrapper(this.tunit).asEquivClass;
     }
 
     if (this.types.includes(TaxonomicUnitWrapper.TYPE_SPECIMEN)) {
-      return new SpecimenWrapper(this.specimen).asEquivClass();
+      return new SpecimenWrapper(this.specimen).asEquivClass;
     }
 
     // Nothing we can do, so just ignore it.

--- a/src/wrappers/TaxonomicUnitWrapper.js
+++ b/src/wrappers/TaxonomicUnitWrapper.js
@@ -196,6 +196,41 @@ class TaxonomicUnitWrapper {
 
     return tunit;
   }
+
+  /**
+   * Return this taxonomic unit as an OWL/JSON-LD object.
+   */
+  asJSONLD() {
+    const jsonld = cloneDeep(this.tunit);
+
+    // Add CDAO_TU as a type to the existing types.
+    if (has(this.tunit, '@type')) {
+      if (isArray(this.tunit['@type'])) this.tunit['@type'].push(owlterms.CDAO_TU);
+    }
+
+    const equivClass = this.asEquivClass();
+    if (equivClass) {
+      jsonld.equivalentClass = equivClass;
+    }
+
+    return jsonld;
+  }
+
+  /**
+   * Return the equivalent class expression for this taxonomic unit.
+   */
+  asEquivClass() {
+    if (this.types.includes(TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT)) {
+      return new TaxonConceptWrapper(this.tunit).asEquivClass();
+    }
+
+    if (this.types.includes(TaxonomicUnitWrapper.TYPE_SPECIMEN)) {
+      return new SpecimenWrapper(this.specimen).asEquivClass();
+    }
+
+    // Nothing we can do, so just ignore it.
+    return undefined;
+  }
 }
 
 module.exports = {

--- a/src/wrappers/TaxonomicUnitWrapper.js
+++ b/src/wrappers/TaxonomicUnitWrapper.js
@@ -208,7 +208,7 @@ class TaxonomicUnitWrapper {
       if (isArray(this.tunit['@type'])) this.tunit['@type'].push(owlterms.CDAO_TU);
     }
 
-    const equivClass = this.asEquivClass;
+    const equivClass = this.asOWLEquivClass;
     if (equivClass) {
       jsonld.equivalentClass = equivClass;
     }
@@ -219,13 +219,13 @@ class TaxonomicUnitWrapper {
   /**
    * Return the equivalent class expression for this taxonomic unit.
    */
-  get asEquivClass() {
+  get asOWLEquivClass() {
     if (this.types.includes(TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT)) {
-      return new TaxonConceptWrapper(this.tunit).asEquivClass;
+      return new TaxonConceptWrapper(this.tunit).asOWLEquivClass;
     }
 
     if (this.types.includes(TaxonomicUnitWrapper.TYPE_SPECIMEN)) {
-      return new SpecimenWrapper(this.specimen).asEquivClass;
+      return new SpecimenWrapper(this.specimen).asOWLEquivClass;
     }
 
     // Nothing we can do, so just ignore it.

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -215,10 +215,8 @@ describe('PhylogenyWrapper', function () {
     describe('#getNodeLabelsMatchedBySpecifier', function () {
       it('should match a specifier to MVZ225749 based on occurrence ID', function () {
         const specifier1 = {
-          referencesTaxonomicUnits: [{
-            '@type': phyx.TaxonomicUnitWrapper.TYPE_SPECIMEN,
-            occurrenceID: 'MVZ:225749',
-          }],
+          '@type': phyx.TaxonomicUnitWrapper.TYPE_SPECIMEN,
+          occurrenceID: 'MVZ:225749',
         };
         expect(wrapper.getNodeLabelsMatchedBySpecifier(specifier1))
           .to.have.members(['MVZ225749']);
@@ -226,10 +224,8 @@ describe('PhylogenyWrapper', function () {
 
       it('should match a specifier to MVZ191016 based on occurrence ID', function () {
         const specifier2 = {
-          referencesTaxonomicUnits: [{
-            '@type': phyx.TaxonomicUnitWrapper.TYPE_SPECIMEN,
-            occurrenceID: 'MVZ:191016',
-          }],
+          '@type': phyx.TaxonomicUnitWrapper.TYPE_SPECIMEN,
+          occurrenceID: 'MVZ:191016',
         };
 
         expect(wrapper.getNodeLabelsMatchedBySpecifier(specifier2))
@@ -238,10 +234,8 @@ describe('PhylogenyWrapper', function () {
 
       it('should match a specifier to node "Rana boylii" based on the parsed scientific name', function () {
         const specifier3 = {
-          referencesTaxonomicUnits: [{
-            '@type': phyx.TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT,
-            nameString: 'Rana boylii',
-          }],
+          '@type': phyx.TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT,
+          nameString: 'Rana boylii',
         };
 
         expect(wrapper.getNodeLabelsMatchedBySpecifier(specifier3))

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -261,11 +261,11 @@ describe('PhylogenyWrapper', function () {
               {
                 '@id': '#_node0',
                 children: ['#_node1', '#_node2'],
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [owlterms.CDAO_NODE],
+                'rdf:type': [owlterms.CDAO_NODE],
               },
               {
                 '@id': '#_node1',
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
+                'rdf:type': [
                   owlterms.CDAO_NODE,
                   {
                     '@type': 'owl:Restriction',
@@ -300,13 +300,13 @@ describe('PhylogenyWrapper', function () {
               {
                 '@id': '#_node2',
                 children: ['#_node3', '#_node4'],
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [owlterms.CDAO_NODE],
+                'rdf:type': [owlterms.CDAO_NODE],
                 parent: '#_node0',
                 siblings: ['#_node1'],
               },
               {
                 '@id': '#_node3',
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
+                'rdf:type': [
                   owlterms.CDAO_NODE,
                   {
                     '@type': 'owl:Restriction',
@@ -340,7 +340,7 @@ describe('PhylogenyWrapper', function () {
               },
               {
                 '@id': '#_node4',
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
+                'rdf:type': [
                   owlterms.CDAO_NODE,
                   {
                     '@type': 'owl:Restriction',

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -201,7 +201,7 @@ describe('PhylogenyWrapper', function () {
         }]);
 
         expect(wrapper.getTaxonomicUnitsForNodeLabel('Rana boylii')).to.deep.equal([{
-          '@type': 'http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept',
+          '@type': owlterms.TDWG_VOC_TAXON_CONCEPT,
           label: 'Rana boylii',
           hasName: {
             '@type': 'http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName',
@@ -254,7 +254,7 @@ describe('PhylogenyWrapper', function () {
           newick: '((Homo_sapiens, Panthera_tigris), Mus_musculus)',
           jsonld: {
             '@id': '#',
-            '@type': 'testcase:PhyloreferenceTestPhylogeny',
+            '@type': owlterms.PHYLOREFERENCE_PHYLOGENY,
             hasRootNode: { '@id': '#_node0' },
             newick: '((Homo_sapiens, Panthera_tigris), Mus_musculus)',
             nodes: [
@@ -268,15 +268,15 @@ describe('PhylogenyWrapper', function () {
                 'rdf:type': [
                   owlterms.CDAO_NODE,
                   {
-                    '@type': 'owl:Restriction',
+                    '@type': owlterms.OWL_RESTRICTION,
                     onProperty: owlterms.CDAO_REPRESENTS_TU,
                     someValuesFrom: {
-                      '@type': 'owl:Restriction',
-                      onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
+                      '@type': owlterms.OWL_RESTRICTION,
+                      onProperty: owlterms.TDWG_VOC_HAS_NAME,
                       someValuesFrom: {
-                        '@type': 'owl:Restriction',
+                        '@type': owlterms.OWL_RESTRICTION,
                         hasValue: 'Mus musculus',
-                        onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete',
+                        onProperty: owlterms.TDWG_VOC_NAME_COMPLETE,
                       },
                     },
                   },
@@ -284,13 +284,13 @@ describe('PhylogenyWrapper', function () {
                 labels: ['Mus_musculus'],
                 parent: '#_node0',
                 representsTaxonomicUnits: [{
-                  '@type': 'http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept',
+                  '@type': owlterms.TDWG_VOC_TAXON_CONCEPT,
                   hasName: {
-                    '@type': 'http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName',
+                    '@type': owlterms.TDWG_VOC_TAXON_NAME,
                     genusPart: 'Mus',
                     label: 'Mus_musculus',
                     nameComplete: 'Mus musculus',
-                    nomenclaturalCode: 'http://purl.obolibrary.org/obo/NOMEN_0000036',
+                    nomenclaturalCode: owlterms.NAME_IN_UNKNOWN_CODE,
                     specificEpithet: 'musculus',
                   },
                   label: 'Mus_musculus',
@@ -309,15 +309,15 @@ describe('PhylogenyWrapper', function () {
                 'rdf:type': [
                   owlterms.CDAO_NODE,
                   {
-                    '@type': 'owl:Restriction',
+                    '@type': owlterms.OWL_RESTRICTION,
                     onProperty: owlterms.CDAO_REPRESENTS_TU,
                     someValuesFrom: {
-                      '@type': 'owl:Restriction',
-                      onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
+                      '@type': owlterms.OWL_RESTRICTION,
+                      onProperty: owlterms.TDWG_VOC_HAS_NAME,
                       someValuesFrom: {
-                        '@type': 'owl:Restriction',
+                        '@type': owlterms.OWL_RESTRICTION,
                         hasValue: 'Panthera tigris',
-                        onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete',
+                        onProperty: owlterms.TDWG_VOC_NAME_COMPLETE,
                       },
                     },
                   },
@@ -325,13 +325,13 @@ describe('PhylogenyWrapper', function () {
                 labels: ['Panthera_tigris'],
                 parent: '#_node2',
                 representsTaxonomicUnits: [{
-                  '@type': 'http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept',
+                  '@type': owlterms.TDWG_VOC_TAXON_CONCEPT,
                   hasName: {
-                    '@type': 'http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName',
+                    '@type': owlterms.TDWG_VOC_TAXON_NAME,
                     genusPart: 'Panthera',
                     label: 'Panthera_tigris',
                     nameComplete: 'Panthera tigris',
-                    nomenclaturalCode: 'http://purl.obolibrary.org/obo/NOMEN_0000036',
+                    nomenclaturalCode: owlterms.NAME_IN_UNKNOWN_CODE,
                     specificEpithet: 'tigris',
                   },
                   label: 'Panthera_tigris',
@@ -343,15 +343,15 @@ describe('PhylogenyWrapper', function () {
                 'rdf:type': [
                   owlterms.CDAO_NODE,
                   {
-                    '@type': 'owl:Restriction',
+                    '@type': owlterms.OWL_RESTRICTION,
                     onProperty: owlterms.CDAO_REPRESENTS_TU,
                     someValuesFrom: {
-                      '@type': 'owl:Restriction',
-                      onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
+                      '@type': owlterms.OWL_RESTRICTION,
+                      onProperty: owlterms.TDWG_VOC_HAS_NAME,
                       someValuesFrom: {
-                        '@type': 'owl:Restriction',
+                        '@type': owlterms.OWL_RESTRICTION,
                         hasValue: 'Homo sapiens',
-                        onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete',
+                        onProperty: owlterms.TDWG_VOC_NAME_COMPLETE,
                       },
                     },
                   },
@@ -360,13 +360,13 @@ describe('PhylogenyWrapper', function () {
                 parent: '#_node2',
                 representsTaxonomicUnits: [
                   {
-                    '@type': 'http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept',
+                    '@type': owlterms.TDWG_VOC_TAXON_CONCEPT,
                     hasName: {
-                      '@type': 'http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName',
+                      '@type': owlterms.TDWG_VOC_TAXON_NAME,
                       genusPart: 'Homo',
                       label: 'Homo_sapiens',
                       nameComplete: 'Homo sapiens',
-                      nomenclaturalCode: 'http://purl.obolibrary.org/obo/NOMEN_0000036',
+                      nomenclaturalCode: owlterms.NAME_IN_UNKNOWN_CODE,
                       specificEpithet: 'sapiens',
                     },
                     label: 'Homo_sapiens',

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -244,6 +244,149 @@ describe('PhylogenyWrapper', function () {
     });
   });
 
+  describe('#asJSONLD', function () {
+    it('should generate the phylogeny in JSON-LD as expected', function () {
+      const expectedResults = [
+        {
+          newick: '((Homo_sapiens, Panthera_tigris), Mus_musculus)',
+          jsonld: {
+            '@id': '#',
+            '@type': 'testcase:PhyloreferenceTestPhylogeny',
+            hasRootNode: { '@id': '#_node0' },
+            newick: '((Homo_sapiens, Panthera_tigris), Mus_musculus)',
+            nodes: [
+              {
+                '@id': '#_node0',
+                children: ['#_node1', '#_node2'],
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
+                  'http://purl.obolibrary.org/obo/CDAO_0000140',
+                ],
+              },
+              {
+                '@id': '#_node1',
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
+                  'http://purl.obolibrary.org/obo/CDAO_0000140',
+                  {
+                    '@type': 'owl:Restriction',
+                    onProperty: 'obo:CDAO_0000187',
+                    someValuesFrom: {
+                      '@type': 'owl:Restriction',
+                      onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
+                      someValuesFrom: {
+                        '@type': 'owl:Restriction',
+                        hasValue: 'Mus musculus',
+                        onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete',
+                      },
+                    },
+                  },
+                ],
+                labels: ['Mus_musculus'],
+                parent: '#_node0',
+                representsTaxonomicUnits: [{
+                  '@type': 'http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept',
+                  hasName: {
+                    '@type': 'http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName',
+                    genusPart: 'Mus',
+                    label: 'Mus_musculus',
+                    nameComplete: 'Mus musculus',
+                    nomenclaturalCode: 'http://purl.obolibrary.org/obo/NOMEN_0000036',
+                    specificEpithet: 'musculus',
+                  },
+                  label: 'Mus_musculus',
+                }],
+                siblings: ['#_node2'],
+              },
+              {
+                '@id': '#_node2',
+                children: ['#_node3', '#_node4'],
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
+                  'http://purl.obolibrary.org/obo/CDAO_0000140',
+                ],
+                parent: '#_node0',
+                siblings: ['#_node1'],
+              },
+              {
+                '@id': '#_node3',
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
+                  'http://purl.obolibrary.org/obo/CDAO_0000140',
+                  {
+                    '@type': 'owl:Restriction',
+                    onProperty: 'obo:CDAO_0000187',
+                    someValuesFrom: {
+                      '@type': 'owl:Restriction',
+                      onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
+                      someValuesFrom: {
+                        '@type': 'owl:Restriction',
+                        hasValue: 'Panthera tigris',
+                        onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete',
+                      },
+                    },
+                  },
+                ],
+                labels: ['Panthera_tigris'],
+                parent: '#_node2',
+                representsTaxonomicUnits: [{
+                  '@type': 'http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept',
+                  hasName: {
+                    '@type': 'http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName',
+                    genusPart: 'Panthera',
+                    label: 'Panthera_tigris',
+                    nameComplete: 'Panthera tigris',
+                    nomenclaturalCode: 'http://purl.obolibrary.org/obo/NOMEN_0000036',
+                    specificEpithet: 'tigris',
+                  },
+                  label: 'Panthera_tigris',
+                }],
+                siblings: ['#_node4'],
+              },
+              {
+                '@id': '#_node4',
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
+                  'http://purl.obolibrary.org/obo/CDAO_0000140',
+                  {
+                    '@type': 'owl:Restriction',
+                    onProperty: 'obo:CDAO_0000187',
+                    someValuesFrom: {
+                      '@type': 'owl:Restriction',
+                      onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
+                      someValuesFrom: {
+                        '@type': 'owl:Restriction',
+                        hasValue: 'Homo sapiens',
+                        onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete',
+                      },
+                    },
+                  },
+                ],
+                labels: ['Homo_sapiens'],
+                parent: '#_node2',
+                representsTaxonomicUnits: [
+                  {
+                    '@type': 'http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept',
+                    hasName: {
+                      '@type': 'http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName',
+                      genusPart: 'Homo',
+                      label: 'Homo_sapiens',
+                      nameComplete: 'Homo sapiens',
+                      nomenclaturalCode: 'http://purl.obolibrary.org/obo/NOMEN_0000036',
+                      specificEpithet: 'sapiens',
+                    },
+                    label: 'Homo_sapiens',
+                  },
+                ],
+                siblings: ['#_node3'],
+              },
+            ],
+          },
+        },
+      ];
+
+      expectedResults.forEach((expected) => {
+        const wrapper = new phyx.PhylogenyWrapper({ newick: expected.newick });
+        expect(wrapper.asJSONLD('#')).to.deep.equal(expected.jsonld);
+      });
+    });
+  });
+
   describe('#getParsedNewickWithIRIs', function () {
     const tests = [
       {

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -6,6 +6,9 @@
 const chai = require('chai');
 const phyx = require('../src');
 
+// Make it easier to access owlterms.
+const owlterms = require('../src/utils/owlterms');
+
 // Use Chai's expect API for testing.
 const expect = chai.expect;
 
@@ -258,17 +261,15 @@ describe('PhylogenyWrapper', function () {
               {
                 '@id': '#_node0',
                 children: ['#_node1', '#_node2'],
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
-                  'http://purl.obolibrary.org/obo/CDAO_0000140',
-                ],
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [owlterms.CDAO_NODE],
               },
               {
                 '@id': '#_node1',
                 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
-                  'http://purl.obolibrary.org/obo/CDAO_0000140',
+                  owlterms.CDAO_NODE,
                   {
                     '@type': 'owl:Restriction',
-                    onProperty: 'obo:CDAO_0000187',
+                    onProperty: owlterms.CDAO_REPRESENTS_TU,
                     someValuesFrom: {
                       '@type': 'owl:Restriction',
                       onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
@@ -299,19 +300,17 @@ describe('PhylogenyWrapper', function () {
               {
                 '@id': '#_node2',
                 children: ['#_node3', '#_node4'],
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
-                  'http://purl.obolibrary.org/obo/CDAO_0000140',
-                ],
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [owlterms.CDAO_NODE],
                 parent: '#_node0',
                 siblings: ['#_node1'],
               },
               {
                 '@id': '#_node3',
                 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
-                  'http://purl.obolibrary.org/obo/CDAO_0000140',
+                  owlterms.CDAO_NODE,
                   {
                     '@type': 'owl:Restriction',
-                    onProperty: 'obo:CDAO_0000187',
+                    onProperty: owlterms.CDAO_REPRESENTS_TU,
                     someValuesFrom: {
                       '@type': 'owl:Restriction',
                       onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
@@ -342,10 +341,10 @@ describe('PhylogenyWrapper', function () {
               {
                 '@id': '#_node4',
                 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
-                  'http://purl.obolibrary.org/obo/CDAO_0000140',
+                  owlterms.CDAO_NODE,
                   {
                     '@type': 'owl:Restriction',
-                    onProperty: 'obo:CDAO_0000187',
+                    onProperty: owlterms.CDAO_REPRESENTS_TU,
                     someValuesFrom: {
                       '@type': 'owl:Restriction',
                       onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -6,6 +6,9 @@
 const chai = require('chai');
 const phyx = require('../src');
 
+// Use owlterms so we don't have to repeat OWL terms.
+const owlterms = require('../src/utils/owlterms');
+
 // We use Chai's Expect API.
 const expect = chai.expect;
 
@@ -200,24 +203,24 @@ describe('PhylorefWrapper', function () {
       }).asJSONLD('#');
       expect(jsonld).to.have.property('equivalentClass');
       expect(jsonld.equivalentClass).to.deep.equal([{
-        '@type': 'owl:Class',
+        '@type': owlterms.OWL_CLASS,
         intersectionOf: [
           {
-            '@type': 'owl:Restriction',
-            onProperty: 'phyloref:includes_TU',
+            '@type': owlterms.OWL_RESTRICTION,
+            onProperty: owlterms.PHYLOREF_INCLUDES_TU,
             someValuesFrom: {
-              '@type': 'owl:Restriction',
+              '@type': owlterms.OWL_RESTRICTION,
               hasValue: 'MVZ:225749',
-              onProperty: 'http://rs.tdwg.org/dwc/terms/occurrenceID',
+              onProperty: owlterms.DWC_OCCURRENCE_ID,
             },
           },
           {
-            '@type': 'owl:Restriction',
-            onProperty: 'phyloref:excludes_TU',
+            '@type': owlterms.OWL_RESTRICTION,
+            onProperty: owlterms.PHYLOREF_EXCLUDES_TU,
             someValuesFrom: {
-              '@type': 'owl:Restriction',
+              '@type': owlterms.OWL_RESTRICTION,
               hasValue: 'MVZ:191016',
-              onProperty: 'http://rs.tdwg.org/dwc/terms/occurrenceID',
+              onProperty: owlterms.DWC_OCCURRENCE_ID,
             },
           },
         ],
@@ -230,30 +233,30 @@ describe('PhylorefWrapper', function () {
       }).asJSONLD('#');
       expect(jsonld).to.have.property('equivalentClass');
       expect(jsonld.equivalentClass).to.deep.equal([{
-        '@type': 'owl:Restriction',
-        onProperty: 'obo:CDAO_0000149',
+        '@type': owlterms.OWL_RESTRICTION,
+        onProperty: owlterms.CDAO_HAS_CHILD,
         someValuesFrom: {
           '@type': 'owl:Class',
           intersectionOf: [
             {
-              '@type': 'owl:Restriction',
-              onProperty: 'phyloref:excludes_TU',
+              '@type': owlterms.OWL_RESTRICTION,
+              onProperty: owlterms.PHYLOREF_EXCLUDES_TU,
               someValuesFrom: {
-                '@type': 'owl:Restriction',
+                '@type': owlterms.OWL_RESTRICTION,
                 hasValue: 'MVZ:191016',
-                onProperty: 'http://rs.tdwg.org/dwc/terms/occurrenceID',
+                onProperty: owlterms.DWC_OCCURRENCE_ID,
               },
             },
             {
-              '@type': 'owl:Restriction',
-              onProperty: 'phyloref:includes_TU',
+              '@type': owlterms.OWL_RESTRICTION,
+              onProperty: owlterms.PHYLOREF_INCLUDES_TU,
               someValuesFrom: {
-                '@type': 'owl:Restriction',
-                onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
+                '@type': owlterms.OWL_RESTRICTION,
+                onProperty: owlterms.TDWG_VOC_HAS_NAME,
                 someValuesFrom: {
-                  '@type': 'owl:Restriction',
+                  '@type': owlterms.OWL_RESTRICTION,
                   hasValue: 'Rana boylii',
-                  onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete',
+                  onProperty: owlterms.TDWG_VOC_NAME_COMPLETE,
                 },
               },
             },

--- a/test/taxonomic-units.js
+++ b/test/taxonomic-units.js
@@ -143,6 +143,35 @@ describe('TaxonomicUnitWrapper', function () {
         });
     });
   });
+  describe('#asEquivClass', function () {
+    it('when given a taxon concept, only the complete name should be present in the equivClass', function () {
+      const wrapper = new phyx.TaxonomicUnitWrapper({
+        '@type': phyx.TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT,
+        nameString: 'Rana luteiventris Thompson, 1913',
+      });
+      expect(wrapper.asEquivClass).to.deep.equal({
+        '@type': 'owl:Restriction',
+        onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
+        someValuesFrom: {
+          '@type': 'owl:Restriction',
+          onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete',
+          hasValue: 'Rana luteiventris',
+        },
+      });
+    });
+    it('when given a specimen, only the occurrence ID should be present in the equivClass', function () {
+      const wrapper = new phyx.TaxonomicUnitWrapper({
+        '@type': phyx.TaxonomicUnitWrapper.TYPE_SPECIMEN,
+        nameString: 'Rana luteiventris',
+        occurrenceID: 'MVZ 225749',
+      });
+      expect(wrapper.asEquivClass).to.deep.equal({
+        '@type': 'owl:Restriction',
+        onProperty: 'http://rs.tdwg.org/dwc/terms/occurrenceID',
+        hasValue: 'MVZ 225749',
+      });
+    });
+  });
 });
 
 describe('TaxonomicUnitMatcher', function () {

--- a/test/taxonomic-units.js
+++ b/test/taxonomic-units.js
@@ -143,13 +143,13 @@ describe('TaxonomicUnitWrapper', function () {
         });
     });
   });
-  describe('#asEquivClass', function () {
+  describe('#asOWLEquivClass', function () {
     it('when given a taxon concept, only the complete name should be present in the equivClass', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({
         '@type': phyx.TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT,
         nameString: 'Rana luteiventris Thompson, 1913',
       });
-      expect(wrapper.asEquivClass).to.deep.equal({
+      expect(wrapper.asOWLEquivClass).to.deep.equal({
         '@type': 'owl:Restriction',
         onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
         someValuesFrom: {
@@ -165,7 +165,7 @@ describe('TaxonomicUnitWrapper', function () {
         nameString: 'Rana luteiventris',
         occurrenceID: 'MVZ 225749',
       });
-      expect(wrapper.asEquivClass).to.deep.equal({
+      expect(wrapper.asOWLEquivClass).to.deep.equal({
         '@type': 'owl:Restriction',
         onProperty: 'http://rs.tdwg.org/dwc/terms/occurrenceID',
         hasValue: 'MVZ 225749',


### PR DESCRIPTION
This PR updates phyx.js to produce Model 2.0 ontologies. It updates TaxonomicUnitWrapper, TaxonConceptWrapper, TaxonNameWrapper and SpecimenWrapper to produce equivalent class expressions for taxonomic units. These are used by PhylogenyWrapper to produce OWL restrictions for nodes, which are added to their `rdf:type` in the form `cdao:represents_TU some [taxonomic unit as equivalent class expression]`.

It also completely replaces the code used to generate JSON-LD from a phyloreference in PhylorefWrapper with the model 2.0 code from the Clade Ontology (phyloref/clade-ontology#58). Note that this code needs better automated testing (see phyloref/clade-ontology#67 for an example).

Finally, we previously modeled specifiers as *containing* one or more taxonomic units. This PR updates the model so that specifiers *are* taxonomic units.

Making these changes has lead to the creation of a new Phyx context file. This allowed us to start changing properties to bring them in line with the new version of the Phyloref ontology (closes #9, #10).

Note that we still use the model 1.0 method for writing down which phyloreferences are expected to resolve to particular node, i.e. by labeling the node with the phyloreference or by using the `testcase:expected_phyloreference_named` property. Implementing that will require updating JPhyloRef to use the model 2.0 method as well, and so I'll do that in a separate PR.

Should be merged after #18 has been reviewed and merged. Closes #4.