### PR TITLE
Minor API improvements for TaxonNameWrapper, PhylorefWrapper and TaxonomicUnitWrapper

### DIFF
--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -17,18 +17,16 @@ class PhylorefWrapper {
   constructor(phyloref) {
     // Wraps the provided phyloreference
     this.phyloref = phyloref;
+  }
 
-    // Reset internal and external specifiers if needed.
-    // if (!has(this.phyloref, 'internalSpecifiers'))
-    //  Vue.set(this.phyloref, 'internalSpecifiers', []);
-    if (!has(this.phyloref, 'internalSpecifiers')) {
-      this.phyloref.internalSpecifiers = [];
-    }
-    // if (!has(this.phyloref, 'externalSpecifiers'))
-    //  Vue.set(this.phyloref, 'externalSpecifiers', []);
-    if (!has(this.phyloref, 'externalSpecifiers')) {
-      this.phyloref.externalSpecifiers = [];
-    }
+  /** Return the internal specifiers of this phyloref (if any). */
+  get internalSpecifiers() {
+    return this.phyloref.internalSpecifiers || [];
+  }
+
+  /** Return the external specifiers of this phyloref (if any). */
+  get externalSpecifiers() {
+    return this.phyloref.externalSpecifiers || [];
   }
 
   get label() {
@@ -50,12 +48,13 @@ class PhylorefWrapper {
     }
   }
 
+  /** Return all the specifiers of this phyloref (if any). */
   get specifiers() {
     // Returns a list of all specifiers by combining the internal and external
     // specifiers into a single list, with internal specifiers before
     // external specifiers.
-    let specifiers = this.phyloref.internalSpecifiers;
-    specifiers = specifiers.concat(this.phyloref.externalSpecifiers);
+    let specifiers = this.internalSpecifiers;
+    specifiers = specifiers.concat(this.externalSpecifiers);
     return specifiers;
   }
 
@@ -63,8 +62,8 @@ class PhylorefWrapper {
     // For a given specifier, return a string indicating whether it is
     // an 'Internal' or 'External' specifier.
 
-    if (this.phyloref.internalSpecifiers.includes(specifier)) return 'Internal';
-    if (this.phyloref.externalSpecifiers.includes(specifier)) return 'External';
+    if (this.internalSpecifiers.includes(specifier)) return 'Internal';
+    if (this.externalSpecifiers.includes(specifier)) return 'External';
     return 'Specifier';
   }
 
@@ -77,11 +76,11 @@ class PhylorefWrapper {
     if (specifierType === 'Internal') {
       // To set a specifier to 'Internal', we might need to delete it from the
       // list of external specifiers first.
-      index = this.phyloref.externalSpecifiers.indexOf(specifier);
-      if (index !== -1) this.phyloref.externalSpecifiers.splice(index, 1);
+      index = this.externalSpecifiers.indexOf(specifier);
+      if (index !== -1) this.externalSpecifiers.splice(index, 1);
 
       // Don't add it to the list of internal specifiers if it's already there.
-      if (!this.phyloref.internalSpecifiers.includes(specifier)) {
+      if (!this.internalSpecifiers.includes(specifier)) {
         this.phyloref.internalSpecifiers.unshift(specifier);
       }
     } else if (specifierType === 'External') {

--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -21,12 +21,20 @@ class PhylorefWrapper {
 
   /** Return the internal specifiers of this phyloref (if any). */
   get internalSpecifiers() {
-    return this.phyloref.internalSpecifiers || [];
+    if (!has(this.phyloref, 'internalSpecifiers')) {
+      this.phyloref.internalSpecifiers = [];
+    }
+
+    return this.phyloref.internalSpecifiers;
   }
 
   /** Return the external specifiers of this phyloref (if any). */
   get externalSpecifiers() {
-    return this.phyloref.externalSpecifiers || [];
+    if (!has(this.phyloref, 'externalSpecifiers')) {
+      this.phyloref.externalSpecifiers = [];
+    }
+
+    return this.phyloref.externalSpecifiers;
   }
 
   get label() {

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -99,7 +99,7 @@ class TaxonNameWrapper {
       };
     }
 
-    // Attempt 1. Look for a binomial name.
+    // Attempt 2. Look for a binomial name.
     if (!txname) {
       results = /^([A-Z][a-z]+)[ _]([a-z-]+\.?)(?:\b|_)/.exec(verbatimName);
 

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -70,6 +70,7 @@ class TaxonNameWrapper {
         nameComplete: `${results[1]} ${results[2]} ${results[3]}`.trim(),
         genusPart: results[1],
         specificEpithet: results[2],
+        infraspecificEpithet: results[3],
       };
     } else {
       // Is it a uninomial name?
@@ -119,11 +120,14 @@ class TaxonNameWrapper {
    * without authority information).
    */
   get nameComplete() {
-    return this.txname.nameComplete;
+    return this.txname.nameComplete
+      || this.trinomialName
+      || this.binomialName
+      || this.uninomialName;
   }
 
   /** Return the uninomial name if there is one. */
-  get uninomial() {
+  get uninomialName() {
     if (has(this.txname, 'uninomial')) return this.txname.uninomial;
 
     // If there is no genus but there is a scientificName, try to extract a genus
@@ -142,6 +146,16 @@ class TaxonNameWrapper {
     // if available.
     if (this.genusPart === undefined || this.specificEpithet === undefined) return undefined;
     return `${this.genusPart} ${this.specificEpithet}`;
+  }
+
+  /** Return the trinomial name if available. */
+  get trinomialName() {
+    if (
+      this.infraspecificEpithet === undefined
+      || this.specificEpithet === undefined
+      || this.genusPart === undefined
+    ) return undefined;
+    return `${this.genusPart} ${this.specificEpithet} ${this.infraspecificEpithet}`;
   }
 
   /** Return the genus part of this scientific name if available. */
@@ -172,6 +186,24 @@ class TaxonNameWrapper {
         this.nomenclaturalCode
       );
       if (has(txname, 'specificEpithet')) return txname.specificEpithet;
+    }
+
+    return undefined;
+  }
+
+  /** Return the infraspecific epithet of this scientific name if available. */
+  get infraspecificEpithet() {
+    // Try to read the specific epithet if available.
+    if (has(this.txname, 'infraspecificEpithet')) return this.txname.infraspecificEpithet;
+
+    // If there is no specific epithet but there is a scientificName, try to
+    // extract a specific epithet from it.
+    if (this.nameComplete) {
+      const txname = TaxonNameWrapper.fromVerbatimName(
+        this.nameComplete,
+        this.nomenclaturalCode
+      );
+      if (has(txname, 'infraspecificEpithet')) return txname.infraspecificEpithet;
     }
 
     return undefined;

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -80,8 +80,10 @@ class TaxonNameWrapper {
     }
 
     // Use a regular expression to parse the verbatimName.
+
+    // Attempt 1. Look for a trinomial name.
     let txname;
-    const results = /^([A-Z][a-z]+)[ _]([a-z-]+\.?)(?:\b|_)\s*([a-z-]*)/.exec(verbatimName);
+    let results = /^([A-Z][a-z]+)[ _]([a-z-]+\.?)(?:\b|_)\s*([a-z-]+)\b/.exec(verbatimName);
 
     if (results) {
       txname = {
@@ -91,20 +93,37 @@ class TaxonNameWrapper {
         nameComplete: `${results[1]} ${results[2]} ${results[3]}`.trim(),
         genusPart: results[1],
         specificEpithet: results[2],
+        infraspecificEpithet: results[3],
       };
+    }
 
-      // Set an infraspecificEpithet if there is one.
-      if (results[3] !== '') txname.infraspecificEpithet = results[3];
-    } else {
+    // Attempt 1. Look for a binomial name.
+    if (!txname) {
+      results = /^([A-Z][a-z]+)[ _]([a-z-]+\.?)(?:\b|_)/.exec(verbatimName);
+
+      if (results) {
+        txname = {
+          '@type': TaxonNameWrapper.TYPE_TAXON_NAME,
+          nomenclaturalCode: nomenCode,
+          label: verbatimName,
+          nameComplete: `${results[1]} ${results[2]}`.trim(),
+          genusPart: results[1],
+          specificEpithet: results[2],
+        };
+      }
+    }
+
+    // Attempt 3. Look for a uninomial name.
+    if (!txname) {
       // Is it a uninomial name?
-      const checkUninomial = /^([A-Z][a-z]+)(?:[_\s]|\b)/.exec(verbatimName);
-      if (checkUninomial) {
+      results = /^([A-Z][a-z]+)(?:[_\s]|\b)/.exec(verbatimName);
+      if (results) {
         txname = {
           '@type': TaxonNameWrapper.TYPE_TAXON_NAME,
           nomenclaturalCode: TaxonNameWrapper.getNomenCodeAsURI(nomenCode),
           label: verbatimName,
-          nameComplete: checkUninomial[1],
-          uninomial: checkUninomial[1],
+          nameComplete: results[1],
+          uninomial: results[1],
         };
       }
     }

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -14,7 +14,7 @@ const { PhyxCacheManager } = require('../utils/PhyxCacheManager');
  *
  * Every instance of this class is expected to have some combination of the
  * following fields:
- *  - label -- the verbatim taxon name
+ *  - rdfs:label -- the verbatim taxon name
  *  - nameComplete -- the complete uninomial, binomial or trinomial name.
  *  - nomenclaturalCode -- the nomenclatural code under which the complete name
  *    should be interpreted.
@@ -31,7 +31,9 @@ const { PhyxCacheManager } = require('../utils/PhyxCacheManager');
  * changing the nameComplete will overwrite the genusPart, specificEpithet and
  * infraspecificEpithet.
  *
- * TODO: Note that the TaxonName ontology recommends dc:title instead of rdfs:label.
+ * Note that the TaxonName ontology recommends dc:title instead of rdfs:label;
+ * however, I like the idea of using dc:title for documents and rdfs:label for
+ * vocabulary terms, so I'm okay with using rdfs:label for the verbatim name.
  */
 class TaxonNameWrapper {
   /**

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -91,8 +91,10 @@ class TaxonNameWrapper {
         nameComplete: `${results[1]} ${results[2]} ${results[3]}`.trim(),
         genusPart: results[1],
         specificEpithet: results[2],
-        infraspecificEpithet: results[3],
       };
+
+      // Set an infraspecificEpithet if there is one.
+      if (results[3] !== '') txname.infraspecificEpithet = results[3];
     } else {
       // Is it a uninomial name?
       const checkUninomial = /^([A-Z][a-z]+)(?:[_\s]|\b)/.exec(verbatimName);

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -132,8 +132,11 @@ class TaxonNameWrapper {
 
     // If there is no genus but there is a scientificName, try to extract a genus
     // from it.
-    if (this.nameComplete) {
-      const txname = TaxonNameWrapper.fromVerbatimName(this.nameComplete, this.nomenclaturalCode);
+    if (this.txname.nameComplete) {
+      const txname = TaxonNameWrapper.fromVerbatimName(
+        this.txname.nameComplete,
+        this.nomenclaturalCode
+      );
       if (has(txname, 'uninomial')) return txname.uninomial;
     }
 
@@ -165,8 +168,11 @@ class TaxonNameWrapper {
 
     // If there is no genus but there is a scientificName, try to extract a genus
     // from it.
-    if (this.nameComplete) {
-      const txname = TaxonNameWrapper.fromVerbatimName(this.nameComplete, this.nomenclaturalCode);
+    if (this.txname.nameComplete) {
+      const txname = TaxonNameWrapper.fromVerbatimName(
+        this.txname.nameComplete,
+        this.nomenclaturalCode
+      );
       if (has(txname, 'genusPart')) return txname.genusPart;
     }
 
@@ -198,7 +204,7 @@ class TaxonNameWrapper {
 
     // If there is no specific epithet but there is a scientificName, try to
     // extract a specific epithet from it.
-    if (this.nameComplete) {
+    if (this.txname.nameComplete) {
       const txname = TaxonNameWrapper.fromVerbatimName(
         this.nameComplete,
         this.nomenclaturalCode

--- a/src/wrappers/TaxonomicUnitWrapper.js
+++ b/src/wrappers/TaxonomicUnitWrapper.js
@@ -198,6 +198,13 @@ class TaxonomicUnitWrapper {
   }
 
   /**
+   * Return the JSON representation of this taxonomic unit, i.e. the object we're wrapping.
+   */
+  get asJSON() {
+    return this.tunit;
+  }
+
+  /**
    * Return this taxonomic unit as an OWL/JSON-LD object.
    */
   get asJSONLD() {

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -65,14 +65,14 @@ describe('PhylorefWrapper', function () {
 
       describe('when a new external specifier is added using .externalSpecifiers', function () {
         it('should return a list with the new specifier', function () {
-          wrapper.phyloref.externalSpecifiers.push(specifier3);
+          wrapper.externalSpecifiers.push(specifier3);
           expect(wrapper.specifiers).to.deep.equal([specifier3]);
         });
       });
 
       describe('when a new external specifier is added using .externalSpecifiers', function () {
         it('should return a list with the new specifier', function () {
-          wrapper.phyloref.externalSpecifiers.push(specifier2);
+          wrapper.externalSpecifiers.push(specifier2);
           expect(wrapper.specifiers).to.deep.equal([specifier3, specifier2]);
         });
       });
@@ -86,7 +86,7 @@ describe('PhylorefWrapper', function () {
 
       describe('when a specifier is added using .externalSpecifiers', function () {
         it('should return the updated list', function () {
-          wrapper.phyloref.externalSpecifiers.push(specifier1);
+          wrapper.externalSpecifiers.push(specifier1);
           expect(wrapper.specifiers).to.deep.equal([specifier3, specifier1]);
         });
       });
@@ -100,7 +100,7 @@ describe('PhylorefWrapper', function () {
 
       describe('when a specifier is added using .internalSpecifiers', function () {
         it('should be included in the list of all specifiers', function () {
-          wrapper.phyloref.internalSpecifiers.push(specifier2);
+          wrapper.internalSpecifiers.push(specifier2);
           expect(wrapper.specifiers).to.deep.equal([specifier1, specifier2, specifier3]);
         });
       });

--- a/test/taxon-names.js
+++ b/test/taxon-names.js
@@ -36,13 +36,22 @@ describe('TaxonNameWrapper', function () {
       expect(wrapper.genusPart).to.equal('Mus');
       expect(wrapper.specificEpithet).to.equal('musculus');
     });
-    it('should ignore authority after a binomial name', function () {
+    it('should be able to parse trinomial names into genus, specific epithet and infraspecific epithet', function () {
       const wrapper = new phyx.TaxonNameWrapper({
-        nameComplete: 'Mus musculus Linnaeus, 1758',
+        nameComplete: 'Mus musculus domesticus',
       });
 
       expect(wrapper.genusPart).to.equal('Mus');
       expect(wrapper.specificEpithet).to.equal('musculus');
+      expect(wrapper.infraspecificEpithet).to.equal('domesticus');
+    });
+    it('should ignore authority after a binomial name', function () {
+      const taxonName = phyx.TaxonNameWrapper.fromVerbatimName('Mus musculus Linnaeus, 1758');
+      expect(taxonName.nameComplete).to.equal('Mus musculus');
+      expect(taxonName.genusPart).to.equal('Mus');
+      expect(taxonName.specificEpithet).to.equal('musculus');
+      expect(taxonName.infraspecificEpithet).to.be.undefined;
+      expect(taxonName.uninomial).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
This PR improves the API of TaxonNameWrapper and PhylorefWrapper. Specifically, it:
- Adds an infraspecificEpithet field to TaxonNameWrapper to read or set the infraspecific epithet.
- TaxonNameWrapper can now parse trinomial names correctly.
- Adds internalSpecifier and externalSpecifier fields to PhylorefWrapper so that these lists can be read; if missing, one will be created and returned.

This is a seemingly random set of changes, but they were all motivated by requirements in the Authoring Tool.