### PR TITLE
Fixes to PhylorefWrapper

### DIFF
--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -17,18 +17,16 @@ class PhylorefWrapper {
   constructor(phyloref) {
     // Wraps the provided phyloreference
     this.phyloref = phyloref;
+  }
 
-    // Reset internal and external specifiers if needed.
-    // if (!has(this.phyloref, 'internalSpecifiers'))
-    //  Vue.set(this.phyloref, 'internalSpecifiers', []);
-    if (!has(this.phyloref, 'internalSpecifiers')) {
-      this.phyloref.internalSpecifiers = [];
-    }
-    // if (!has(this.phyloref, 'externalSpecifiers'))
-    //  Vue.set(this.phyloref, 'externalSpecifiers', []);
-    if (!has(this.phyloref, 'externalSpecifiers')) {
-      this.phyloref.externalSpecifiers = [];
-    }
+  /** Return the internal specifiers of this phyloref (if any). */
+  get internalSpecifiers() {
+    return this.phyloref.internalSpecifiers || [];
+  }
+
+  /** Return the external specifiers of this phyloref (if any). */
+  get externalSpecifiers() {
+    return this.phyloref.externalSpecifiers || [];
   }
 
   get label() {
@@ -50,12 +48,13 @@ class PhylorefWrapper {
     }
   }
 
+  /** Return all the specifiers of this phyloref (if any). */
   get specifiers() {
     // Returns a list of all specifiers by combining the internal and external
     // specifiers into a single list, with internal specifiers before
     // external specifiers.
-    let specifiers = this.phyloref.internalSpecifiers;
-    specifiers = specifiers.concat(this.phyloref.externalSpecifiers);
+    let specifiers = this.internalSpecifiers;
+    specifiers = specifiers.concat(this.externalSpecifiers);
     return specifiers;
   }
 
@@ -63,8 +62,8 @@ class PhylorefWrapper {
     // For a given specifier, return a string indicating whether it is
     // an 'Internal' or 'External' specifier.
 
-    if (this.phyloref.internalSpecifiers.includes(specifier)) return 'Internal';
-    if (this.phyloref.externalSpecifiers.includes(specifier)) return 'External';
+    if (this.internalSpecifiers.includes(specifier)) return 'Internal';
+    if (this.externalSpecifiers.includes(specifier)) return 'External';
     return 'Specifier';
   }
 
@@ -77,11 +76,11 @@ class PhylorefWrapper {
     if (specifierType === 'Internal') {
       // To set a specifier to 'Internal', we might need to delete it from the
       // list of external specifiers first.
-      index = this.phyloref.externalSpecifiers.indexOf(specifier);
-      if (index !== -1) this.phyloref.externalSpecifiers.splice(index, 1);
+      index = this.externalSpecifiers.indexOf(specifier);
+      if (index !== -1) this.externalSpecifiers.splice(index, 1);
 
       // Don't add it to the list of internal specifiers if it's already there.
-      if (!this.phyloref.internalSpecifiers.includes(specifier)) {
+      if (!this.internalSpecifiers.includes(specifier)) {
         this.phyloref.internalSpecifiers.unshift(specifier);
       }
     } else if (specifierType === 'External') {

--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -21,12 +21,20 @@ class PhylorefWrapper {
 
   /** Return the internal specifiers of this phyloref (if any). */
   get internalSpecifiers() {
-    return this.phyloref.internalSpecifiers || [];
+    if (!has(this.phyloref, 'internalSpecifiers')) {
+      this.phyloref.internalSpecifiers = [];
+    }
+
+    return this.phyloref.internalSpecifiers;
   }
 
   /** Return the external specifiers of this phyloref (if any). */
   get externalSpecifiers() {
-    return this.phyloref.externalSpecifiers || [];
+    if (!has(this.phyloref, 'externalSpecifiers')) {
+      this.phyloref.externalSpecifiers = [];
+    }
+
+    return this.phyloref.externalSpecifiers;
   }
 
   get label() {

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -80,8 +80,10 @@ class TaxonNameWrapper {
     }
 
     // Use a regular expression to parse the verbatimName.
+
+    // Attempt 1. Look for a trinomial name.
     let txname;
-    const results = /^([A-Z][a-z]+)[ _]([a-z-]+\.?)(?:\b|_)\s*([a-z-]*)/.exec(verbatimName);
+    let results = /^([A-Z][a-z]+)[ _]([a-z-]+\.?)(?:\b|_)\s*([a-z-]+)\b/.exec(verbatimName);
 
     if (results) {
       txname = {
@@ -91,20 +93,37 @@ class TaxonNameWrapper {
         nameComplete: `${results[1]} ${results[2]} ${results[3]}`.trim(),
         genusPart: results[1],
         specificEpithet: results[2],
+        infraspecificEpithet: results[3],
       };
+    }
 
-      // Set an infraspecificEpithet if there is one.
-      if (results[3] !== '') txname.infraspecificEpithet = results[3];
-    } else {
+    // Attempt 1. Look for a binomial name.
+    if (!txname) {
+      results = /^([A-Z][a-z]+)[ _]([a-z-]+\.?)(?:\b|_)/.exec(verbatimName);
+
+      if (results) {
+        txname = {
+          '@type': TaxonNameWrapper.TYPE_TAXON_NAME,
+          nomenclaturalCode: nomenCode,
+          label: verbatimName,
+          nameComplete: `${results[1]} ${results[2]}`.trim(),
+          genusPart: results[1],
+          specificEpithet: results[2],
+        };
+      }
+    }
+
+    // Attempt 3. Look for a uninomial name.
+    if (!txname) {
       // Is it a uninomial name?
-      const checkUninomial = /^([A-Z][a-z]+)(?:[_\s]|\b)/.exec(verbatimName);
-      if (checkUninomial) {
+      results = /^([A-Z][a-z]+)(?:[_\s]|\b)/.exec(verbatimName);
+      if (results) {
         txname = {
           '@type': TaxonNameWrapper.TYPE_TAXON_NAME,
           nomenclaturalCode: TaxonNameWrapper.getNomenCodeAsURI(nomenCode),
           label: verbatimName,
-          nameComplete: checkUninomial[1],
-          uninomial: checkUninomial[1],
+          nameComplete: results[1],
+          uninomial: results[1],
         };
       }
     }

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -65,14 +65,14 @@ describe('PhylorefWrapper', function () {
 
       describe('when a new external specifier is added using .externalSpecifiers', function () {
         it('should return a list with the new specifier', function () {
-          wrapper.phyloref.externalSpecifiers.push(specifier3);
+          wrapper.externalSpecifiers.push(specifier3);
           expect(wrapper.specifiers).to.deep.equal([specifier3]);
         });
       });
 
       describe('when a new external specifier is added using .externalSpecifiers', function () {
         it('should return a list with the new specifier', function () {
-          wrapper.phyloref.externalSpecifiers.push(specifier2);
+          wrapper.externalSpecifiers.push(specifier2);
           expect(wrapper.specifiers).to.deep.equal([specifier3, specifier2]);
         });
       });
@@ -86,7 +86,7 @@ describe('PhylorefWrapper', function () {
 
       describe('when a specifier is added using .externalSpecifiers', function () {
         it('should return the updated list', function () {
-          wrapper.phyloref.externalSpecifiers.push(specifier1);
+          wrapper.externalSpecifiers.push(specifier1);
           expect(wrapper.specifiers).to.deep.equal([specifier3, specifier1]);
         });
       });
@@ -100,7 +100,7 @@ describe('PhylorefWrapper', function () {
 
       describe('when a specifier is added using .internalSpecifiers', function () {
         it('should be included in the list of all specifiers', function () {
-          wrapper.phyloref.internalSpecifiers.push(specifier2);
+          wrapper.internalSpecifiers.push(specifier2);
           expect(wrapper.specifiers).to.deep.equal([specifier1, specifier2, specifier3]);
         });
       });


### PR DESCRIPTION
PhylorefWrapper used to add externalSpecifier and internalSpecifier fields to all wrapped phyloreferences. This PR modifies PhylorefWrapper so that it only adds those fields when necessary.

WIP