### PR TITLE
Fix npm lint invocation and fix syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Phyloreference Exchange (PHYX) library in JavaScript",
   "main": "src/index.js",
   "scripts": {
-    "lint": "eslint src/index.js \"test/**\" --ext .js",
+    "lint": "eslint \"src/**\" \"test/**\" --ext .js",
     "pretest": "npm run lint",
     "test": "mocha",
     "docs": "esdoc"

--- a/src/matchers/TaxonomicUnitMatcher.js
+++ b/src/matchers/TaxonomicUnitMatcher.js
@@ -1,7 +1,5 @@
-const { has } = require('lodash');
 const { TaxonomicUnitWrapper } = require('../wrappers/TaxonomicUnitWrapper');
 const { TaxonConceptWrapper } = require('../wrappers/TaxonConceptWrapper');
-const { TaxonNameWrapper } = require('../wrappers/TaxonNameWrapper');
 const { SpecimenWrapper } = require('../wrappers/SpecimenWrapper');
 
 /**

--- a/src/wrappers/PhylogenyWrapper.js
+++ b/src/wrappers/PhylogenyWrapper.js
@@ -5,7 +5,7 @@
 const { has } = require('lodash');
 
 /** Used to parse Newick strings. */
-const { parse: parseNewick } = require('newick-js');
+const parseNewick = require('newick-js').parse;
 
 /** OWL terms to be used here. */
 const owlterms = require('../utils/owlterms');

--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -2,7 +2,6 @@
 const moment = require('moment');
 const { has, cloneDeep } = require('lodash');
 
-const owlterms = require('../utils/owlterms');
 const { TaxonomicUnitWrapper } = require('./TaxonomicUnitWrapper');
 const { PhylogenyWrapper } = require('./PhylogenyWrapper');
 


### PR DESCRIPTION
This PR updates package.json so that running `npm run lint` runs ESLint on all source files. It also fixes some syntax issues that fixing the lint invocation exposed, as well as one syntactical issue that prevented `esdocs` from generating documentation for PhylogenyWrapper.