### PR TITLE
Improve nomenclatural code implementation in TaxonNameWrapper

### DIFF
--- a/src/wrappers/TaxonConceptWrapper.js
+++ b/src/wrappers/TaxonConceptWrapper.js
@@ -122,30 +122,34 @@ class TaxonConceptWrapper {
    *
    * @return A taxonomic unit that corresponds to this taxon concept.
    */
-  static fromLabel(nodeLabel) {
+  static fromLabel(nodeLabel, nomenCode) {
     if (nodeLabel === undefined || nodeLabel === null || nodeLabel.trim() === '') return undefined;
 
     // Check if this label can be divided into a name and a sensu/sec component.
     const match = /^\s*(.*)\s+(?:sec|sensu)\.?\s+(.*)\s*$/.exec(nodeLabel);
+    let accordingTo;
     if (match) {
-      return {
-        '@type': TaxonConceptWrapper.TYPE_TAXON_CONCEPT,
-        nameString: match[1],
-        accordingTo: match[2],
-      };
+      accordingTo = match[2];
     }
 
     // Can we parse it as a taxon name? If not, we will return undefined.
-    const taxonName = TaxonNameWrapper.fromVerbatimName(nodeLabel);
+    const taxonName = TaxonNameWrapper.fromVerbatimName(nodeLabel, nomenCode);
     if (taxonName) {
-      return {
-        '@type': TaxonConceptWrapper.TYPE_TAXON_CONCEPT,
-        hasName: taxonName,
-      };
+      return TaxonConceptWrapper.wrapTaxonName(taxonName, accordingTo);
     }
 
     // Couldn't parse it at all.
     return undefined;
+  }
+
+  /** Wrap a taxon name with a particular TaxonName object and an accordingTo (string). */
+  static wrapTaxonName(taxonName, accordingTo) {
+    const result = {
+      '@type': TaxonConceptWrapper.TYPE_TAXON_CONCEPT,
+      hasName: taxonName,
+    };
+    if (accordingTo) result.accordingTo = accordingTo;
+    return result;
   }
 
   /**

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -419,6 +419,8 @@ class TaxonNameWrapper {
     // No complete name, can't return anything.
     if (!this.nameComplete) return undefined;
 
+    // Note that until we figure out how to set up nomenclatural codes on
+    // phylogenies, we don't incorporate that into the OWL equiv class.
     return {
       '@type': 'owl:Restriction',
       onProperty: owlterms.TDWG_VOC_NAME_COMPLETE,

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -79,7 +79,7 @@ class TaxonNameWrapper {
       {
         uri: owlterms.ICN_NAME,
         shortName: 'ICN',
-        label: 'Algae, fungi and plants (ICNafp or ICBN)',
+        label: 'Algae, fungi and plants (ICN, previously ICBN)',
         title: 'International Code of Nomenclature for algae, fungi, and plants',
       },
       {
@@ -96,8 +96,8 @@ class TaxonNameWrapper {
       },
       {
         uri: owlterms.NAME_IN_UNKNOWN_CODE,
-        shortName: 'Unknown',
-        label: 'Code not known',
+        shortName: 'Code not known',
+        label: 'Nomenclatural code not known',
         title: 'Nomenclatural code not known',
       },
     ];

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -51,6 +51,13 @@ class TaxonNameWrapper {
   }
 
   /**
+   * The URI for an unknown nomenclatural code (i.e. all we know is that it's a scientific name).
+   */
+  static get NAME_IN_UNKNOWN_CODE() {
+    return owlterms.NAME_IN_UNKNOWN_CODE;
+  }
+
+  /**
    * Return a list of all supported nomenclatural code. Each entry will have
    * the following keys:
    *  - code: A list of short names that can be used to represent this nomenclatural code.
@@ -64,46 +71,70 @@ class TaxonNameWrapper {
   static getNomenclaturalCodes() {
     return [
       {
-        code: ['iczn'],
+        shortName: 'ICZN',
         label: 'Zoological name (ICZN)',
         title: 'International Code of Zoological Nomenclature',
         uri: owlterms.ICZN_NAME,
       },
       {
-        code: ['icn', 'icbn', 'icnafp'],
+        shortName: 'ICNafp',
         label: 'Algae, fungi and plants (ICNafp or ICBN)',
         title: 'International Code of Nomenclature for algae, fungi, and plants',
         uri: owlterms.ICN_NAME,
       },
       {
-        code: ['icnp'],
+        shortName: 'ICNP',
         label: 'Prokaryotes (ICNP)',
         title: 'International Code of Nomenclature of Prokaryotes',
         uri: owlterms.ICNP_NAME,
       },
       {
-        code: ['ictv'],
+        shortName: 'ICTV',
         label: 'Viruses (ICTV)',
         title: 'International Committee on Taxonomy of Viruses',
         uri: owlterms.ICTV_NAME,
-      },
-      {
-        code: ['unknown'],
-        label: 'Unknown',
-        title: 'Unknown nomenclatural code',
-        uri: owlterms.NAME_IN_UNKNOWN_CODE,
       },
     ];
   }
 
   /**
-   * Returns the URI for a particular nomenclature code.
+   * Returns the nomenclatural code entry for a code.
    */
-  static getNomenCodeAsURI(nomenCode) {
+  static getNomenCodeAsObject(nomenCodeURI) {
     const codes = TaxonNameWrapper.getNomenclaturalCodes();
-    const matchingCode = codes.find(code => code.code.includes(nomenCode.toLowerCase()));
-    if (matchingCode) return matchingCode.uri;
-    return owlterms.NAME_IN_UNKNOWN_CODE;
+
+    // Look for the entry with the same URI as the provided URI.
+    const matchingCode = codes
+      .find(code => code.uri.toLowerCase() === nomenCodeURI.toLowerCase());
+    if (matchingCode) return matchingCode;
+    return undefined;
+  }
+
+  /**
+   * Returns the nomenclatural code of this taxon name.
+   */
+  get nomenclaturalCode() {
+    return this.txname.nomenclaturalCode;
+  }
+
+  /**
+   * Returns the nomenclatural code of this taxon name as a URI.
+   */
+  get nomenclaturalCodeAsObject() {
+    const nomenCode = this.txname.nomenclaturalCode;
+    if (!nomenCode) return undefined;
+
+    const nomenObj = TaxonNameWrapper.getNomenCodeAsObject(nomenCode);
+    if (!nomenObj) return undefined;
+
+    return nomenObj;
+  }
+
+  /**
+   * Set the nomenclatural code of this taxon name.
+   */
+  set nomenclaturalCode(nomenCode) {
+    this.txname.nomenclaturalCode = nomenCode;
   }
 
   /**
@@ -188,27 +219,6 @@ class TaxonNameWrapper {
       // If we don't have a nameComplete, treat this as the name complete.
       this.nameComplete = lab;
     }
-  }
-
-  /**
-   * Return the nomenclatural code of this taxon name.
-   */
-  get nomenclaturalCode() {
-    return this.txname.nomenclaturalCode || TaxonNameWrapper.getNomenCodeAsURI('unknown');
-  }
-
-  /**
-   * Return whether or not this taxon name has a nomenclatural code set.
-   */
-  hasNomenclaturalCode() {
-    return has(this.txname, 'nomenclaturalCode') && this.txname.nomenclaturalCode !== TaxonNameWrapper.getNomenCodeAsURI('unknown');
-  }
-
-  /**
-   * Set the nomenclatural code of this taxon name.
-   */
-  set nomenclaturalCode(nomenCode) {
-    this.txname.nomenclaturalCode = nomenCode;
   }
 
   /**

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -78,7 +78,7 @@ class TaxonNameWrapper {
       },
       {
         uri: owlterms.ICN_NAME,
-        shortName: 'ICNafp',
+        shortName: 'ICN',
         label: 'Algae, fungi and plants (ICNafp or ICBN)',
         title: 'International Code of Nomenclature for algae, fungi, and plants',
       },

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -88,7 +88,7 @@ class TaxonNameWrapper {
     if (results) {
       txname = {
         '@type': TaxonNameWrapper.TYPE_TAXON_NAME,
-        nomenclaturalCode: TaxonNameWrapper.getNomenCodeAsURI(nomenCode),
+        nomenclaturalCode: nomenCode,
         label: verbatimName,
         nameComplete: `${results[1]} ${results[2]} ${results[3]}`.trim(),
         genusPart: results[1],
@@ -120,7 +120,7 @@ class TaxonNameWrapper {
       if (results) {
         txname = {
           '@type': TaxonNameWrapper.TYPE_TAXON_NAME,
-          nomenclaturalCode: TaxonNameWrapper.getNomenCodeAsURI(nomenCode),
+          nomenclaturalCode: nomenCode,
           label: verbatimName,
           nameComplete: results[1],
           uninomial: results[1],
@@ -159,6 +159,13 @@ class TaxonNameWrapper {
    */
   get nomenclaturalCode() {
     return this.txname.nomenclaturalCode || TaxonNameWrapper.getNomenCodeAsURI('unknown');
+  }
+
+  /**
+   * Set the nomenclatural code of this taxon name.
+   */
+  set nomenclaturalCode(nomenCode) {
+    this.txname.nomenclaturalCode = nomenCode;
   }
 
   /**
@@ -332,7 +339,7 @@ class TaxonNameWrapper {
   /**
    * Return this taxon name in an JSON-LD representation.
    */
-  asJSONLD() {
+  get asJSONLD() {
     const jsonld = cloneDeep(this.txname);
 
     // Make sure '@type' is an array.

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -71,28 +71,34 @@ class TaxonNameWrapper {
   static getNomenclaturalCodes() {
     return [
       {
+        uri: owlterms.ICZN_NAME,
         shortName: 'ICZN',
         label: 'Zoological name (ICZN)',
         title: 'International Code of Zoological Nomenclature',
-        uri: owlterms.ICZN_NAME,
       },
       {
+        uri: owlterms.ICN_NAME,
         shortName: 'ICNafp',
         label: 'Algae, fungi and plants (ICNafp or ICBN)',
         title: 'International Code of Nomenclature for algae, fungi, and plants',
-        uri: owlterms.ICN_NAME,
       },
       {
+        uri: owlterms.ICNP_NAME,
         shortName: 'ICNP',
         label: 'Prokaryotes (ICNP)',
         title: 'International Code of Nomenclature of Prokaryotes',
-        uri: owlterms.ICNP_NAME,
       },
       {
+        uri: owlterms.ICTV_NAME,
         shortName: 'ICTV',
         label: 'Viruses (ICTV)',
         title: 'International Committee on Taxonomy of Viruses',
-        uri: owlterms.ICTV_NAME,
+      },
+      {
+        uri: owlterms.NAME_IN_UNKNOWN_CODE,
+        shortName: 'Unknown',
+        label: 'Code not known',
+        title: 'Nomenclatural code not known',
       },
     ];
   }

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -51,23 +51,59 @@ class TaxonNameWrapper {
   }
 
   /**
+   * Return a list of all supported nomenclatural code. Each entry will have
+   * the following keys:
+   *  - code: A list of short names that can be used to represent this nomenclatural code.
+   *  - label: An informal name of this nomenclatural code in English.
+   *  - title: The formal name of this nomenclatural code in English.
+   *  - uri: The URI of this nomenclatural code.
+   *
+   * This will be used in drawing user interfaces, so this should be in order
+   * of likelihood of use.
+   */
+  static getNomenclaturalCodes() {
+    return [
+      {
+        code: ['iczn'],
+        label: 'Zoological name (ICZN)',
+        title: 'International Code of Zoological Nomenclature',
+        uri: owlterms.ICZN_NAME,
+      },
+      {
+        code: ['icn', 'icbn', 'icnafp'],
+        label: 'Algae, fungi and plants (ICNafp or ICBN)',
+        title: 'International Code of Nomenclature for algae, fungi, and plants',
+        uri: owlterms.ICN_NAME,
+      },
+      {
+        code: ['icnp'],
+        label: 'Prokaryotes (ICNP)',
+        title: 'International Code of Nomenclature of Prokaryotes',
+        uri: owlterms.ICNP_NAME,
+      },
+      {
+        code: ['ictv'],
+        label: 'Viruses (ICTV)',
+        title: 'International Committee on Taxonomy of Viruses',
+        uri: owlterms.ICTV_NAME,
+      },
+      {
+        code: ['unknown'],
+        label: 'Unknown',
+        title: 'Unknown nomenclatural code',
+        uri: owlterms.NAME_IN_UNKNOWN_CODE,
+      },
+    ];
+  }
+
+  /**
    * Returns the URI for a particular nomenclature code.
    */
-  static getNomenCodeAsURI(name) {
-    switch (name.toLowerCase()) {
-      case 'iczn':
-        return owlterms.ICZN_NAME;
-      case 'icn':
-      case 'icbn':
-      case 'icnafp':
-        return owlterms.ICN_NAME;
-      case 'ictv':
-        return owlterms.ICTV_NAME;
-      case 'icnp':
-        return owlterms.ICNP_NAME;
-      default:
-        return owlterms.NAME_IN_UNKNOWN_CODE;
-    }
+  static getNomenCodeAsURI(nomenCode) {
+    const codes = TaxonNameWrapper.getNomenclaturalCodes();
+    const matchingCode = codes.find(code => code.code.includes(nomenCode.toLowerCase()));
+    if (matchingCode) return matchingCode.uri;
+    return owlterms.NAME_IN_UNKNOWN_CODE;
   }
 
   /**

--- a/src/wrappers/TaxonNameWrapper.js
+++ b/src/wrappers/TaxonNameWrapper.js
@@ -198,6 +198,13 @@ class TaxonNameWrapper {
   }
 
   /**
+   * Return whether or not this taxon name has a nomenclatural code set.
+   */
+  hasNomenclaturalCode() {
+    return has(this.txname, 'nomenclaturalCode') && this.txname.nomenclaturalCode !== TaxonNameWrapper.getNomenCodeAsURI('unknown');
+  }
+
+  /**
    * Set the nomenclatural code of this taxon name.
    */
   set nomenclaturalCode(nomenCode) {


### PR DESCRIPTION
We previously used nomenclature code short names (e.g. "iucn") that were translated into URIs when writing out the taxon name as JSON-LD. This PR changes that API to use the URIs primarily to identify nomenclatural codes. TaxonNameWrapper also includes a list of nomenclatural codes that can be used to provide short names, labels and titles, which is useful for populating user interfaces. Closes #5.