### PR TITLE
Bugfix: CDAO_NODE type treated as string rather than URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 
 ## [Unreleased]
 - Updated all NPM packages to their latest version.
+- Fixed a bug in which node's types were not being correctly set to obo:CDAO\_0000140.
 
 ## [0.2.0] - 2019-07-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this library will be documented in this file.
 The format is based on [Keep a Changelog] and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
+
+## [0.2.1] - 2019-08-15
 - Updated all NPM packages to their latest version.
 - Fixed a bug in which node's types were not being correctly set to obo:CDAO\_0000140.
 
@@ -31,6 +33,7 @@ release of this package was based on [commit 14d2c3d5d1] in that repository.
 - Made other changes to the initial code as needed to work as an independent NPM package.
 
   [Unreleased]: https://github.com/phyloref/phyx.js/compare/v0.2.0...master
+  [0.2.1]: https://github.com/phyloref/phyx.js/compare/v0.2.0...v0.2.1
   [0.2.0]: https://github.com/phyloref/phyx.js/compare/v0.1.2...v0.2.0
   [0.1.2]: https://github.com/phyloref/phyx.js/compare/v0.1.1...v0.1.2
   [0.1.1]: https://github.com/phyloref/phyx.js/compare/v0.1.0...v0.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phyloref/phyx",
-  "version": "0.2.1-rc1",
+  "version": "0.2.1",
   "description": "Classes and methods that help read and manipulate components of Phyloreference Exchange (PHYX) format files",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phyloref/phyx",
-  "version": "0.2.0",
+  "version": "0.2.1-rc1",
   "description": "Classes and methods that help read and manipulate components of Phyloreference Exchange (PHYX) format files",
   "main": "src/index.js",
   "scripts": {

--- a/src/wrappers/PhylogenyWrapper.js
+++ b/src/wrappers/PhylogenyWrapper.js
@@ -322,7 +322,7 @@ class PhylogenyWrapper {
         // can't support @type being an array (despite that being in the standard,
         // see https://w3c.github.io/json-ld-syntax/#example-14-specifying-multiple-types-for-a-node),
         // so we fall back to using rdf:type instead.
-        nodeAsJSONLD[owlterms.RDF_TYPE] = [owlterms.CDAO_NODE];
+        nodeAsJSONLD[owlterms.RDF_TYPE] = [{ '@id': owlterms.CDAO_NODE }];
 
         // Add labels, additional node properties and taxonomic units.
         if (has(node, 'name') && node.name !== '') {

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -261,12 +261,12 @@ describe('PhylogenyWrapper', function () {
               {
                 '@id': '#_node0',
                 children: ['#_node1', '#_node2'],
-                'rdf:type': [owlterms.CDAO_NODE],
+                'rdf:type': [{ '@id': owlterms.CDAO_NODE }],
               },
               {
                 '@id': '#_node1',
                 'rdf:type': [
-                  owlterms.CDAO_NODE,
+                  { '@id': owlterms.CDAO_NODE },
                   {
                     '@type': owlterms.OWL_RESTRICTION,
                     onProperty: owlterms.CDAO_REPRESENTS_TU,
@@ -300,14 +300,14 @@ describe('PhylogenyWrapper', function () {
               {
                 '@id': '#_node2',
                 children: ['#_node3', '#_node4'],
-                'rdf:type': [owlterms.CDAO_NODE],
+                'rdf:type': [{ '@id': owlterms.CDAO_NODE }],
                 parent: '#_node0',
                 siblings: ['#_node1'],
               },
               {
                 '@id': '#_node3',
                 'rdf:type': [
-                  owlterms.CDAO_NODE,
+                  { '@id': owlterms.CDAO_NODE },
                   {
                     '@type': owlterms.OWL_RESTRICTION,
                     onProperty: owlterms.CDAO_REPRESENTS_TU,
@@ -341,7 +341,7 @@ describe('PhylogenyWrapper', function () {
               {
                 '@id': '#_node4',
                 'rdf:type': [
-                  owlterms.CDAO_NODE,
+                  { '@id': owlterms.CDAO_NODE },
                   {
                     '@type': owlterms.OWL_RESTRICTION,
                     onProperty: owlterms.CDAO_REPRESENTS_TU,


### PR DESCRIPTION
This PR fixes a bug in JSON-LD generation in which phylogeny nodes were not being described correctly, since the CDAO_NODE type was being specified as a string rather than a URI.

Once reviewed, I'll publish this to NPM as 0.2.1.

This bug. combined with WebserverCommand's checking of resolved nodes to make sure that they are typed as nodes (see phyloref/jphyloref#53), are why the Open Tree Resolver was behaving oddly at Evolution 2019.