### PR TITLE
Process new expected resolution syntax

### DIFF
--- a/src/utils/owlterms.js
+++ b/src/utils/owlterms.js
@@ -45,4 +45,12 @@ module.exports = {
   ICN_NAME: 'http://purl.obolibrary.org/obo/NOMEN_0000109',
   ICNP_NAME: 'http://purl.obolibrary.org/obo/NOMEN_0000110',
   ICTV_NAME: 'http://purl.obolibrary.org/obo/NOMEN_0000111',
+
+  // Terms from the Relation Ontology.
+  RO_HAS_EVIDENCE: 'obo:RO_0002558',
+
+  // Terms from the Ontology for Biomedical Investigations.
+  OBI_HAS_SPECIFIED_INPUT: 'obo:OBI_0000293',
+  OBI_IS_SPECIFIED_OUTPUT_OF: 'obo:OBI_0000312',
+  OBI_PREDICTION: 'obo:OBI_0302910',
 };

--- a/src/utils/owlterms.js
+++ b/src/utils/owlterms.js
@@ -46,9 +46,6 @@ module.exports = {
   ICNP_NAME: 'http://purl.obolibrary.org/obo/NOMEN_0000110',
   ICTV_NAME: 'http://purl.obolibrary.org/obo/NOMEN_0000111',
 
-  // Terms from the Relation Ontology.
-  RO_HAS_EVIDENCE: 'obo:RO_0002558',
-
   // Terms from the Ontology for Biomedical Investigations.
   OBI_HAS_SPECIFIED_INPUT: 'obo:OBI_0000293',
   OBI_IS_SPECIFIED_OUTPUT_OF: 'obo:OBI_0000312',

--- a/src/wrappers/PhyxWrapper.js
+++ b/src/wrappers/PhyxWrapper.js
@@ -1,5 +1,5 @@
 /** Used to make deep copies of objects. */
-const { has, cloneDeep, keys } = require('lodash');
+const { has, cloneDeep } = require('lodash');
 
 const owlterms = require('../utils/owlterms');
 


### PR DESCRIPTION
The expected resolution information in Phyx files will shortly be changed in Phyx files (PR phyloref/curation-tool#173). This PR updates phyx.js so that it can convert the expected resolution information into the model 2.0 representation. For a particular node, we describe it as follows (where `#phyloref3` is a phyloreference in this Phyx file):
> obi:is_specified_output_of **some** ( obi:Prediction **and** obi:has_specified_output **some** *#phyloref3*)

Closes #38.