### PR TITLE
Make baseURI editable in PhyxWrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Classes and methods that help read and manipulate components of Phyloreference Exchange (PHYX) format files",
   "main": "src/index.js",
   "scripts": {
-    "lint": "eslint \"src/**\" \"test/**\" --ext .js",
+    "lint": "eslint \"src/**/*.js\" \"test/**/*.js\"",
     "pretest": "npm run lint",
     "test": "mocha",
     "docs": "esdoc"

--- a/src/wrappers/PhyxWrapper.js
+++ b/src/wrappers/PhyxWrapper.js
@@ -15,14 +15,15 @@ class PhyxWrapper {
   /**
    * Wraps an entire PHYX document.
    * @param {Object} phyx - The Phyx structure to wrap.
-   * @param {function(newick: string): {name: string, children: Object[]}} newickParser - A method
+   * @param {function(newick: string): {name: string, children: Object[]}}
+   *    [newickParser=PhylogenyWrapper.getParsedNewick] - A method
    *    that accepts a Newick string and returns a list of nodes. Each node should have a
    *    'children' key with its children and optionally a 'name' key with its label. This
    *    code previously depended on phylotree.js, whose newick_parser() function works exactly
    *    like this. This option allows you to drop in Phylotree's newick_parser() or -- if you
    *    prefer -- any other option.
    */
-  constructor(phyx, newickParser) {
+  constructor(phyx, newickParser = PhylogenyWrapper.getParsedNewick) {
     //
     this.phyx = phyx;
     this.newickParser = newickParser;
@@ -36,19 +37,19 @@ class PhyxWrapper {
    *    2. We have to convert phylogenies into OWL restrictions.
    *    3. Insert all matches between taxonomic units in this file.
    *
-   * @param {string} [baseURI=""] - The base URI to use when generating this Phyx document.
+   * @param {string} [baseURI="#"] - The base URI to use when generating this Phyx document.
    * @return {Object} This Phyx document as an OWL ontology as a JSON-LD object.
    */
-  asOWLOntology(baseURI = '') {
+  asOWLOntology(baseURI = '#') {
     const jsonld = cloneDeep(this.phyx);
 
     // Some helper methods for generating base URIs for phylorefs and phylogenies.
     function getBaseURIForPhyloref(index) {
-      return `${baseURI}#phyloref${index}`;
+      return `${baseURI}phyloref${index}`;
     }
 
     function getBaseURIForPhylogeny(index) {
-      return `${baseURI}#phylogeny${index}`;
+      return `${baseURI}phylogeny${index}`;
     }
 
     // Convert phyloreferences into an OWL class restriction

--- a/src/wrappers/PhyxWrapper.js
+++ b/src/wrappers/PhyxWrapper.js
@@ -14,8 +14,8 @@ const { TaxonomicUnitMatcher } = require('../matchers/TaxonomicUnitMatcher');
 class PhyxWrapper {
   /**
    * Wraps an entire PHYX document.
-   * @param {Object} phyx - the Phyx structure to wrap.
-   * @param {function(newick: string): {children: Object[], name: string}} newickParser - a method
+   * @param {Object} phyx - The Phyx structure to wrap.
+   * @param {function(newick: string): {name: string, children: Object[]}} newickParser - A method
    *    that accepts a Newick string and returns a list of nodes. Each node should have a
    *    'children' key with its children and optionally a 'name' key with its label. This
    *    code previously depended on phylotree.js, whose newick_parser() function works exactly
@@ -30,14 +30,14 @@ class PhyxWrapper {
 
   /**
    * Generate an executable ontology from this Phyx document. The document is mostly in JSON-LD
-   * already, except for two important things:
+   * already, except for three important things:
    *    1. We have to convert all phylogenies into a series of statements relating to the nodes
    *       inside these phylogenies.
    *    2. We have to convert phylogenies into OWL restrictions.
    *    3. Insert all matches between taxonomic units in this file.
    *
    * @param {string} [baseURI=""] - The base URI to use when generating this Phyx document.
-   * @return {string} This Phyx document as an OWL ontology in JSON-LD.
+   * @return {Object} This Phyx document as an OWL ontology as a JSON-LD object.
    */
   asOWLOntology(baseURI = '') {
     const jsonld = cloneDeep(this.phyx);

--- a/test/examples.js
+++ b/test/examples.js
@@ -16,10 +16,13 @@ const expect = chai.expect;
 
 describe('PhyxWrapper', function () {
   describe('convert brochu_2003.json to an OWL ontology', function () {
+    const jsonFilename = path.resolve(__dirname, './examples/brochu_2003.json');
+    const jsonldFilename = path.resolve(__dirname, './examples/brochu_2003.jsonld');
+
     let brochu2003;
 
     it('should be able to load brochu_2003.json', function () {
-      brochu2003 = JSON.parse(fs.readFileSync(path.resolve(__dirname, './examples/brochu_2003.json')));
+      brochu2003 = JSON.parse(fs.readFileSync(jsonFilename));
       expect(brochu2003).to.be.an('object');
     });
 
@@ -27,11 +30,12 @@ describe('PhyxWrapper', function () {
     it('should be able to convert brochu_2003.json to an OWL Ontology', function () {
       this.timeout(10000);
       brochu2003owl = new phyx.PhyxWrapper(brochu2003).asOWLOntology('http://example.org/brochu_2003.json#');
+      // fs.writeFileSync(jsonldFilename, JSON.stringify(brochu2003owl, null, 2));
       expect(brochu2003owl).to.be.an('object');
     });
 
     it('should generate the same OWL ontology as it generated earlier', function () {
-      const expectedBrochu2003 = JSON.parse(fs.readFileSync(path.resolve(__dirname, './examples/brochu_2003.jsonld')));
+      const expectedBrochu2003 = JSON.parse(fs.readFileSync(jsonldFilename));
       expect(brochu2003owl).to.be.deep.equal(expectedBrochu2003);
     });
   });

--- a/test/examples.js
+++ b/test/examples.js
@@ -1,0 +1,38 @@
+/*
+ * Test conversion on example files.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const chai = require('chai');
+const phyx = require('../src');
+
+const expect = chai.expect;
+
+/**
+ * Test whether conversion of Phyx files to an OWL ontology occurs predictably.
+ */
+
+describe('PhyxWrapper', function () {
+  describe('convert brochu_2003.json to an OWL ontology', function () {
+    let brochu2003;
+
+    it('should be able to load brochu_2003.json', function () {
+      brochu2003 = JSON.parse(fs.readFileSync(path.resolve(__dirname, './examples/brochu_2003.json')));
+      expect(brochu2003).to.be.an('object');
+    });
+
+    let brochu2003owl;
+    it('should be able to convert brochu_2003.json to an OWL Ontology', function () {
+      this.timeout(10000);
+      brochu2003owl = new phyx.PhyxWrapper(brochu2003).asOWLOntology('http://example.org/brochu_2003.json#');
+      expect(brochu2003owl).to.be.an('object');
+    });
+
+    it('should generate the same OWL ontology as it generated earlier', function () {
+      const expectedBrochu2003 = JSON.parse(fs.readFileSync(path.resolve(__dirname, './examples/brochu_2003.jsonld')));
+      expect(brochu2003owl).to.be.deep.equal(expectedBrochu2003);
+    });
+  });
+});

--- a/test/examples/brochu_2003.json
+++ b/test/examples/brochu_2003.json
@@ -1,0 +1,263 @@
+{
+    "@context": "../../docs/context/v0.3.0/phyx.json",
+    "doi": "10.1146/annurev.earth.31.100901.141308",
+    "url": "https://www.annualreviews.org/doi/10.1146/annurev.earth.31.100901.141308",
+    "citation": "Brochu (2003) Annual Review of Earth and Planetary Sciences 31:357-397",
+    "phylogenies": [
+        {
+            "newick": "(Parasuchia,(rauisuchians,Aetosauria,(sphenosuchians,(protosuchians,(mesosuchians,(Hylaeochampsa,Aegyptosuchus,Stomatosuchus,(Allodaposuchus,('Gavialis gangeticus',(('Diplocynodon ratelii',('Alligator mississippiensis','Caiman crocodilus')Alligatoridae)Alligatoroidea,('Tomistoma schlegelii',('Osteolaemus tetraspis','Crocodylus niloticus')Crocodylinae)Crocodylidae)Brevirostres)Crocodylia))Eusuchia)Mesoeucrocodylia)Crocodyliformes)Crocodylomorpha))root;",
+            "label": "Fig 1 from Brochu 2003",
+            "@id": "#phylogeny0"
+        }
+    ],
+    "phylorefs": [
+        {
+            "label": "Alligatoridae",
+            "cladeDefinition": "Alligatoridae (Cuvier 1807).\n\nLast common ancestor of Alligator mississippiensis and Caiman crocodilus and all of its descendents.",
+            "internalSpecifiers": [
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Caiman crocodilus",
+                        "nameComplete": "Caiman crocodilus",
+                        "genusPart": "Caiman",
+                        "specificEpithet": "crocodilus"
+                    }
+                },
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    },
+                    "label": "Alligator mississippiensis"
+                }
+            ],
+            "externalSpecifiers": [],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:31.471Z"
+                    }
+                }
+            ]
+        },
+        {
+            "label": "Alligatorinae",
+            "cladeDefinition": "Alligatorinae (Kälin 1940).\n\nAlligator mississippiensis and all crocodylians closer to it than to Caiman crocodilus.",
+            "internalSpecifiers": [
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Caiman crocodilus",
+                        "nameComplete": "Caiman crocodilus",
+                        "genusPart": "Caiman",
+                        "specificEpithet": "crocodilus"
+                    },
+                    "label": "Caiman crocodilus"
+                }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:36.063Z"
+                    }
+                }
+            ],
+            "expectedResolution": {
+                "#phylogeny0": {
+                    "nodeLabel": "Alligator mississippiensis"
+                }
+            }
+        },
+        {
+            "label": "Caimaninae",
+            "cladeDefinition": "Caimaninae (Norell 1988).\n\nCaiman crocodilus and all crocodylians closer to it than to Alligator mississippiensis.",
+            "internalSpecifiers": [
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Caiman crocodilus",
+                        "nameComplete": "Caiman crocodilus",
+                        "genusPart": "Caiman",
+                        "specificEpithet": "crocodilus"
+                    }
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
+                }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:42.007Z"
+                    }
+                }
+            ],
+            "expectedResolution": {
+                "#phylogeny0": {
+                    "nodeLabel": "Caiman crocodilus"
+                }
+            }
+        },
+        {
+            "label": "Crocodyloidea",
+            "cladeDefinition": "Crocodyloidea (Fitzinger 1826).\n\nCrocodylus niloticus and all crocodylians closer to it than to Alligator mississippiensis or Gavialis gangeticus.",
+            "internalSpecifiers": [
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    },
+                    "label": "Alligator mississippiensis"
+                },
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Gavialis gangeticus",
+                        "nameComplete": "Gavialis gangeticus",
+                        "genusPart": "Gavialis",
+                        "specificEpithet": "gangeticus"
+                    },
+                    "label": "Gavialis gangeticus"
+                }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:under-review"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:48.240Z"
+                    }
+                }
+            ],
+            "expectedResolution": {
+                "#phylogeny0": {
+                    "nodeLabel": "Crocodylidae"
+                }
+            }
+        },
+        {
+            "label": "Crocodylidae",
+            "cladeDefinition": "Crocodylidae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nLast common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.",
+            "internalSpecifiers": [
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Tomistoma schlegelii",
+                        "nameComplete": "Tomistoma schlegelii",
+                        "genusPart": "Tomistoma",
+                        "specificEpithet": "schlegelii"
+                    }
+                },
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Osteolaemus tetraspis",
+                        "nameComplete": "Osteolaemus tetraspis",
+                        "genusPart": "Osteolaemus",
+                        "specificEpithet": "tetraspis"
+                    },
+                    "label": "Osteolaemus tetraspis"
+                },
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    },
+                    "label": "Crocodylus niloticus"
+                }
+            ],
+            "externalSpecifiers": [],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:51.960Z"
+                    }
+                }
+            ]
+        }
+    ],
+    "title": "Phylogenetic Approaches Toward Crocodylian History",
+    "defaultNomenclaturalCodeURI": "http://purl.obolibrary.org/obo/NOMEN_0000107"
+}

--- a/test/examples/brochu_2003.jsonld
+++ b/test/examples/brochu_2003.jsonld
@@ -1,0 +1,2338 @@
+{
+  "@context": "../../docs/context/v0.3.0/phyx.json",
+  "doi": "10.1146/annurev.earth.31.100901.141308",
+  "url": "https://www.annualreviews.org/doi/10.1146/annurev.earth.31.100901.141308",
+  "citation": "Brochu (2003) Annual Review of Earth and Planetary Sciences 31:357-397",
+  "phylogenies": [
+    {
+      "newick": "(Parasuchia,(rauisuchians,Aetosauria,(sphenosuchians,(protosuchians,(mesosuchians,(Hylaeochampsa,Aegyptosuchus,Stomatosuchus,(Allodaposuchus,('Gavialis gangeticus',(('Diplocynodon ratelii',('Alligator mississippiensis','Caiman crocodilus')Alligatoridae)Alligatoroidea,('Tomistoma schlegelii',('Osteolaemus tetraspis','Crocodylus niloticus')Crocodylinae)Crocodylidae)Brevirostres)Crocodylia))Eusuchia)Mesoeucrocodylia)Crocodyliformes)Crocodylomorpha))root;",
+      "label": "Fig 1 from Brochu 2003",
+      "@id": "#phylogeny0",
+      "@type": "testcase:PhyloreferenceTestPhylogeny",
+      "nodes": [
+        {
+          "@id": "#phylogeny0_node0",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            }
+          ],
+          "labels": [
+            "root"
+          ],
+          "representsTaxonomicUnits": [],
+          "children": [
+            "#phylogeny0_node1",
+            "#phylogeny0_node29"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node1",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            }
+          ],
+          "parent": "#phylogeny0_node0",
+          "siblings": [
+            "#phylogeny0_node29"
+          ],
+          "children": [
+            "#phylogeny0_node2",
+            "#phylogeny0_node27",
+            "#phylogeny0_node28"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node2",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Crocodylomorpha"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Crocodylomorpha"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Crocodylomorpha",
+                "nameComplete": "Crocodylomorpha",
+                "uninomial": "Crocodylomorpha"
+              },
+              "label": "Crocodylomorpha"
+            }
+          ],
+          "parent": "#phylogeny0_node1",
+          "siblings": [
+            "#phylogeny0_node27",
+            "#phylogeny0_node28"
+          ],
+          "children": [
+            "#phylogeny0_node3",
+            "#phylogeny0_node26"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node3",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Crocodyliformes"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Crocodyliformes"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Crocodyliformes",
+                "nameComplete": "Crocodyliformes",
+                "uninomial": "Crocodyliformes"
+              },
+              "label": "Crocodyliformes"
+            }
+          ],
+          "parent": "#phylogeny0_node2",
+          "siblings": [
+            "#phylogeny0_node26"
+          ],
+          "children": [
+            "#phylogeny0_node4",
+            "#phylogeny0_node25"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node4",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Mesoeucrocodylia"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Mesoeucrocodylia"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Mesoeucrocodylia",
+                "nameComplete": "Mesoeucrocodylia",
+                "uninomial": "Mesoeucrocodylia"
+              },
+              "label": "Mesoeucrocodylia"
+            }
+          ],
+          "parent": "#phylogeny0_node3",
+          "siblings": [
+            "#phylogeny0_node25"
+          ],
+          "children": [
+            "#phylogeny0_node5",
+            "#phylogeny0_node24"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node5",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Eusuchia"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Eusuchia"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Eusuchia",
+                "nameComplete": "Eusuchia",
+                "uninomial": "Eusuchia"
+              },
+              "label": "Eusuchia"
+            }
+          ],
+          "parent": "#phylogeny0_node4",
+          "siblings": [
+            "#phylogeny0_node24"
+          ],
+          "children": [
+            "#phylogeny0_node6",
+            "#phylogeny0_node21",
+            "#phylogeny0_node22",
+            "#phylogeny0_node23"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node6",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            }
+          ],
+          "parent": "#phylogeny0_node5",
+          "siblings": [
+            "#phylogeny0_node21",
+            "#phylogeny0_node22",
+            "#phylogeny0_node23"
+          ],
+          "children": [
+            "#phylogeny0_node7",
+            "#phylogeny0_node20"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node7",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Crocodylia"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Crocodylia"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Crocodylia",
+                "nameComplete": "Crocodylia",
+                "uninomial": "Crocodylia"
+              },
+              "label": "Crocodylia"
+            }
+          ],
+          "parent": "#phylogeny0_node6",
+          "siblings": [
+            "#phylogeny0_node20"
+          ],
+          "children": [
+            "#phylogeny0_node8",
+            "#phylogeny0_node19"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node8",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Brevirostres"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Brevirostres"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Brevirostres",
+                "nameComplete": "Brevirostres",
+                "uninomial": "Brevirostres"
+              },
+              "label": "Brevirostres"
+            }
+          ],
+          "parent": "#phylogeny0_node7",
+          "siblings": [
+            "#phylogeny0_node19"
+          ],
+          "children": [
+            "#phylogeny0_node9",
+            "#phylogeny0_node14"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node9",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Crocodylidae"
+                }
+              }
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:OBI_0000312",
+              "someValuesFrom": {
+                "@type": "owl:Class",
+                "intersectionOf": [
+                  {
+                    "@id": "obo:OBI_0302910"
+                  },
+                  {
+                    "@type": "owl:Restriction",
+                    "onProperty": "obo:OBI_0000293",
+                    "someValuesFrom": {
+                      "@id": "http://example.org/brochu_2003.json#phyloref3"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:OBI_0000312",
+              "someValuesFrom": {
+                "@type": "owl:Class",
+                "intersectionOf": [
+                  {
+                    "@id": "obo:OBI_0302910"
+                  },
+                  {
+                    "@type": "owl:Restriction",
+                    "onProperty": "obo:OBI_0000293",
+                    "someValuesFrom": {
+                      "@id": "http://example.org/brochu_2003.json#phyloref4"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "labels": [
+            "Crocodylidae"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Crocodylidae",
+                "nameComplete": "Crocodylidae",
+                "uninomial": "Crocodylidae"
+              },
+              "label": "Crocodylidae"
+            }
+          ],
+          "parent": "#phylogeny0_node8",
+          "siblings": [
+            "#phylogeny0_node14"
+          ],
+          "children": [
+            "#phylogeny0_node10",
+            "#phylogeny0_node13"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node10",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Crocodylinae"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Crocodylinae"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Crocodylinae",
+                "nameComplete": "Crocodylinae",
+                "uninomial": "Crocodylinae"
+              },
+              "label": "Crocodylinae"
+            }
+          ],
+          "parent": "#phylogeny0_node9",
+          "siblings": [
+            "#phylogeny0_node13"
+          ],
+          "children": [
+            "#phylogeny0_node11",
+            "#phylogeny0_node12"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node11",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Crocodylus niloticus"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Crocodylus niloticus"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Crocodylus niloticus",
+                "nameComplete": "Crocodylus niloticus",
+                "genusPart": "Crocodylus",
+                "specificEpithet": "niloticus"
+              },
+              "label": "Crocodylus niloticus"
+            }
+          ],
+          "parent": "#phylogeny0_node10",
+          "siblings": [
+            "#phylogeny0_node12"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node12",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Osteolaemus tetraspis"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Osteolaemus tetraspis"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Osteolaemus tetraspis",
+                "nameComplete": "Osteolaemus tetraspis",
+                "genusPart": "Osteolaemus",
+                "specificEpithet": "tetraspis"
+              },
+              "label": "Osteolaemus tetraspis"
+            }
+          ],
+          "parent": "#phylogeny0_node10",
+          "siblings": [
+            "#phylogeny0_node11"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node13",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Tomistoma schlegelii"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Tomistoma schlegelii"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Tomistoma schlegelii",
+                "nameComplete": "Tomistoma schlegelii",
+                "genusPart": "Tomistoma",
+                "specificEpithet": "schlegelii"
+              },
+              "label": "Tomistoma schlegelii"
+            }
+          ],
+          "parent": "#phylogeny0_node9",
+          "siblings": [
+            "#phylogeny0_node10"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node14",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Alligatoroidea"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Alligatoroidea"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Alligatoroidea",
+                "nameComplete": "Alligatoroidea",
+                "uninomial": "Alligatoroidea"
+              },
+              "label": "Alligatoroidea"
+            }
+          ],
+          "parent": "#phylogeny0_node8",
+          "siblings": [
+            "#phylogeny0_node9"
+          ],
+          "children": [
+            "#phylogeny0_node15",
+            "#phylogeny0_node18"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node15",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Alligatoridae"
+                }
+              }
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:OBI_0000312",
+              "someValuesFrom": {
+                "@type": "owl:Class",
+                "intersectionOf": [
+                  {
+                    "@id": "obo:OBI_0302910"
+                  },
+                  {
+                    "@type": "owl:Restriction",
+                    "onProperty": "obo:OBI_0000293",
+                    "someValuesFrom": {
+                      "@id": "http://example.org/brochu_2003.json#phyloref0"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "labels": [
+            "Alligatoridae"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Alligatoridae",
+                "nameComplete": "Alligatoridae",
+                "uninomial": "Alligatoridae"
+              },
+              "label": "Alligatoridae"
+            }
+          ],
+          "parent": "#phylogeny0_node14",
+          "siblings": [
+            "#phylogeny0_node18"
+          ],
+          "children": [
+            "#phylogeny0_node16",
+            "#phylogeny0_node17"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node16",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Caiman crocodilus"
+                }
+              }
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:OBI_0000312",
+              "someValuesFrom": {
+                "@type": "owl:Class",
+                "intersectionOf": [
+                  {
+                    "@id": "obo:OBI_0302910"
+                  },
+                  {
+                    "@type": "owl:Restriction",
+                    "onProperty": "obo:OBI_0000293",
+                    "someValuesFrom": {
+                      "@id": "http://example.org/brochu_2003.json#phyloref2"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "labels": [
+            "Caiman crocodilus"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Caiman crocodilus",
+                "nameComplete": "Caiman crocodilus",
+                "genusPart": "Caiman",
+                "specificEpithet": "crocodilus"
+              },
+              "label": "Caiman crocodilus"
+            }
+          ],
+          "parent": "#phylogeny0_node15",
+          "siblings": [
+            "#phylogeny0_node17"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node17",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Alligator mississippiensis"
+                }
+              }
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:OBI_0000312",
+              "someValuesFrom": {
+                "@type": "owl:Class",
+                "intersectionOf": [
+                  {
+                    "@id": "obo:OBI_0302910"
+                  },
+                  {
+                    "@type": "owl:Restriction",
+                    "onProperty": "obo:OBI_0000293",
+                    "someValuesFrom": {
+                      "@id": "http://example.org/brochu_2003.json#phyloref1"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "labels": [
+            "Alligator mississippiensis"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Alligator mississippiensis",
+                "nameComplete": "Alligator mississippiensis",
+                "genusPart": "Alligator",
+                "specificEpithet": "mississippiensis"
+              },
+              "label": "Alligator mississippiensis"
+            }
+          ],
+          "parent": "#phylogeny0_node15",
+          "siblings": [
+            "#phylogeny0_node16"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node18",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Diplocynodon ratelii"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Diplocynodon ratelii"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Diplocynodon ratelii",
+                "nameComplete": "Diplocynodon ratelii",
+                "genusPart": "Diplocynodon",
+                "specificEpithet": "ratelii"
+              },
+              "label": "Diplocynodon ratelii"
+            }
+          ],
+          "parent": "#phylogeny0_node14",
+          "siblings": [
+            "#phylogeny0_node15"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node19",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Gavialis gangeticus"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Gavialis gangeticus"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Gavialis gangeticus",
+                "nameComplete": "Gavialis gangeticus",
+                "genusPart": "Gavialis",
+                "specificEpithet": "gangeticus"
+              },
+              "label": "Gavialis gangeticus"
+            }
+          ],
+          "parent": "#phylogeny0_node7",
+          "siblings": [
+            "#phylogeny0_node8"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node20",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Allodaposuchus"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Allodaposuchus"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Allodaposuchus",
+                "nameComplete": "Allodaposuchus",
+                "uninomial": "Allodaposuchus"
+              },
+              "label": "Allodaposuchus"
+            }
+          ],
+          "parent": "#phylogeny0_node6",
+          "siblings": [
+            "#phylogeny0_node7"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node21",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Stomatosuchus"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Stomatosuchus"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Stomatosuchus",
+                "nameComplete": "Stomatosuchus",
+                "uninomial": "Stomatosuchus"
+              },
+              "label": "Stomatosuchus"
+            }
+          ],
+          "parent": "#phylogeny0_node5",
+          "siblings": [
+            "#phylogeny0_node6",
+            "#phylogeny0_node22",
+            "#phylogeny0_node23"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node22",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Aegyptosuchus"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Aegyptosuchus"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Aegyptosuchus",
+                "nameComplete": "Aegyptosuchus",
+                "uninomial": "Aegyptosuchus"
+              },
+              "label": "Aegyptosuchus"
+            }
+          ],
+          "parent": "#phylogeny0_node5",
+          "siblings": [
+            "#phylogeny0_node6",
+            "#phylogeny0_node21",
+            "#phylogeny0_node23"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node23",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Hylaeochampsa"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Hylaeochampsa"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Hylaeochampsa",
+                "nameComplete": "Hylaeochampsa",
+                "uninomial": "Hylaeochampsa"
+              },
+              "label": "Hylaeochampsa"
+            }
+          ],
+          "parent": "#phylogeny0_node5",
+          "siblings": [
+            "#phylogeny0_node6",
+            "#phylogeny0_node21",
+            "#phylogeny0_node22"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node24",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            }
+          ],
+          "labels": [
+            "mesosuchians"
+          ],
+          "representsTaxonomicUnits": [],
+          "parent": "#phylogeny0_node4",
+          "siblings": [
+            "#phylogeny0_node5"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node25",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            }
+          ],
+          "labels": [
+            "protosuchians"
+          ],
+          "representsTaxonomicUnits": [],
+          "parent": "#phylogeny0_node3",
+          "siblings": [
+            "#phylogeny0_node4"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node26",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            }
+          ],
+          "labels": [
+            "sphenosuchians"
+          ],
+          "representsTaxonomicUnits": [],
+          "parent": "#phylogeny0_node2",
+          "siblings": [
+            "#phylogeny0_node3"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node27",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Aetosauria"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Aetosauria"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Aetosauria",
+                "nameComplete": "Aetosauria",
+                "uninomial": "Aetosauria"
+              },
+              "label": "Aetosauria"
+            }
+          ],
+          "parent": "#phylogeny0_node1",
+          "siblings": [
+            "#phylogeny0_node2",
+            "#phylogeny0_node28"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node28",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            }
+          ],
+          "labels": [
+            "rauisuchians"
+          ],
+          "representsTaxonomicUnits": [],
+          "parent": "#phylogeny0_node1",
+          "siblings": [
+            "#phylogeny0_node2",
+            "#phylogeny0_node27"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node29",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Parasuchia"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Parasuchia"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Parasuchia",
+                "nameComplete": "Parasuchia",
+                "uninomial": "Parasuchia"
+              },
+              "label": "Parasuchia"
+            }
+          ],
+          "parent": "#phylogeny0_node0",
+          "siblings": [
+            "#phylogeny0_node1"
+          ]
+        }
+      ],
+      "hasRootNode": {
+        "@id": "#phylogeny0_node0"
+      }
+    }
+  ],
+  "phylorefs": [
+    {
+      "label": "Alligatoridae",
+      "cladeDefinition": "Alligatoridae (Cuvier 1807).\n\nLast common ancestor of Alligator mississippiensis and Caiman crocodilus and all of its descendents.",
+      "internalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Caiman crocodilus",
+            "nameComplete": "Caiman crocodilus",
+            "genusPart": "Caiman",
+            "specificEpithet": "crocodilus"
+          }
+        },
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Alligator mississippiensis",
+            "nameComplete": "Alligator mississippiensis",
+            "genusPart": "Alligator",
+            "specificEpithet": "mississippiensis"
+          },
+          "label": "Alligator mississippiensis"
+        }
+      ],
+      "externalSpecifiers": [],
+      "pso:holdsStatusInTime": [
+        {
+          "@type": "http://purl.org/spar/pso/StatusInTime",
+          "pso:withStatus": {
+            "@id": "pso:submitted"
+          },
+          "tvc:atTime": {
+            "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:31.471Z"
+          }
+        }
+      ],
+      "@id": "http://example.org/brochu_2003.json#phyloref0",
+      "@type": "owl:Class",
+      "subClassOf": "phyloref:Phyloreference",
+      "hasAdditionalClass": [],
+      "equivalentClass": [
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Caiman crocodilus"
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:includes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Alligator mississippiensis"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "label": "Alligatorinae",
+      "cladeDefinition": "Alligatorinae (Kälin 1940).\n\nAlligator mississippiensis and all crocodylians closer to it than to Caiman crocodilus.",
+      "internalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Alligator mississippiensis",
+            "nameComplete": "Alligator mississippiensis",
+            "genusPart": "Alligator",
+            "specificEpithet": "mississippiensis"
+          }
+        }
+      ],
+      "externalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Caiman crocodilus",
+            "nameComplete": "Caiman crocodilus",
+            "genusPart": "Caiman",
+            "specificEpithet": "crocodilus"
+          },
+          "label": "Caiman crocodilus"
+        }
+      ],
+      "pso:holdsStatusInTime": [
+        {
+          "@type": "http://purl.org/spar/pso/StatusInTime",
+          "pso:withStatus": {
+            "@id": "pso:submitted"
+          },
+          "tvc:atTime": {
+            "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:36.063Z"
+          }
+        }
+      ],
+      "expectedResolution": {
+        "#phylogeny0": {
+          "nodeLabel": "Alligator mississippiensis"
+        }
+      },
+      "@id": "http://example.org/brochu_2003.json#phyloref1",
+      "@type": "owl:Class",
+      "subClassOf": "phyloref:Phyloreference",
+      "hasAdditionalClass": [],
+      "equivalentClass": [
+        {
+          "@type": "owl:Class",
+          "intersectionOf": [
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "phyloref:includes_TU",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Alligator mississippiensis"
+                }
+              }
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "phyloref:excludes_TU",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Caiman crocodilus"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Caimaninae",
+      "cladeDefinition": "Caimaninae (Norell 1988).\n\nCaiman crocodilus and all crocodylians closer to it than to Alligator mississippiensis.",
+      "internalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Caiman crocodilus",
+            "nameComplete": "Caiman crocodilus",
+            "genusPart": "Caiman",
+            "specificEpithet": "crocodilus"
+          }
+        }
+      ],
+      "externalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Alligator mississippiensis",
+            "nameComplete": "Alligator mississippiensis",
+            "genusPart": "Alligator",
+            "specificEpithet": "mississippiensis"
+          }
+        }
+      ],
+      "pso:holdsStatusInTime": [
+        {
+          "@type": "http://purl.org/spar/pso/StatusInTime",
+          "pso:withStatus": {
+            "@id": "pso:submitted"
+          },
+          "tvc:atTime": {
+            "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:42.007Z"
+          }
+        }
+      ],
+      "expectedResolution": {
+        "#phylogeny0": {
+          "nodeLabel": "Caiman crocodilus"
+        }
+      },
+      "@id": "http://example.org/brochu_2003.json#phyloref2",
+      "@type": "owl:Class",
+      "subClassOf": "phyloref:Phyloreference",
+      "hasAdditionalClass": [],
+      "equivalentClass": [
+        {
+          "@type": "owl:Class",
+          "intersectionOf": [
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "phyloref:includes_TU",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Caiman crocodilus"
+                }
+              }
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "phyloref:excludes_TU",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Alligator mississippiensis"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Crocodyloidea",
+      "cladeDefinition": "Crocodyloidea (Fitzinger 1826).\n\nCrocodylus niloticus and all crocodylians closer to it than to Alligator mississippiensis or Gavialis gangeticus.",
+      "internalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Crocodylus niloticus",
+            "nameComplete": "Crocodylus niloticus",
+            "genusPart": "Crocodylus",
+            "specificEpithet": "niloticus"
+          }
+        }
+      ],
+      "externalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Alligator mississippiensis",
+            "nameComplete": "Alligator mississippiensis",
+            "genusPart": "Alligator",
+            "specificEpithet": "mississippiensis"
+          },
+          "label": "Alligator mississippiensis"
+        },
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Gavialis gangeticus",
+            "nameComplete": "Gavialis gangeticus",
+            "genusPart": "Gavialis",
+            "specificEpithet": "gangeticus"
+          },
+          "label": "Gavialis gangeticus"
+        }
+      ],
+      "pso:holdsStatusInTime": [
+        {
+          "@type": "http://purl.org/spar/pso/StatusInTime",
+          "pso:withStatus": {
+            "@id": "pso:under-review"
+          },
+          "tvc:atTime": {
+            "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:48.240Z"
+          }
+        }
+      ],
+      "expectedResolution": {
+        "#phylogeny0": {
+          "nodeLabel": "Crocodylidae"
+        }
+      },
+      "@id": "http://example.org/brochu_2003.json#phyloref3",
+      "@type": "owl:Class",
+      "subClassOf": "phyloref:Phyloreference",
+      "hasAdditionalClass": [
+        {
+          "@id": "http://example.org/brochu_2003.json#phyloref3_additional1",
+          "@type": "owl:Class",
+          "subClassOf": "phyloref:PhyloreferenceUsingMinimumClade",
+          "equivalentClass": [
+            {
+              "@type": "owl:Class",
+              "intersectionOf": [
+                {
+                  "@type": "owl:Restriction",
+                  "onProperty": "phyloref:includes_TU",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                    "someValuesFrom": {
+                      "@type": "owl:Restriction",
+                      "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                      "hasValue": "Crocodylus niloticus"
+                    }
+                  }
+                },
+                {
+                  "@type": "owl:Restriction",
+                  "onProperty": "phyloref:excludes_TU",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                    "someValuesFrom": {
+                      "@type": "owl:Restriction",
+                      "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                      "hasValue": "Alligator mississippiensis"
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "label": "(Crocodylus niloticus ~ Alligator mississippiensis)"
+        },
+        {
+          "@id": "http://example.org/brochu_2003.json#phyloref3_additional2",
+          "@type": "owl:Class",
+          "subClassOf": "phyloref:PhyloreferenceUsingMinimumClade",
+          "equivalentClass": [
+            {
+              "@type": "owl:Class",
+              "intersectionOf": [
+                {
+                  "@type": "owl:Restriction",
+                  "onProperty": "phyloref:includes_TU",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                    "someValuesFrom": {
+                      "@type": "owl:Restriction",
+                      "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                      "hasValue": "Crocodylus niloticus"
+                    }
+                  }
+                },
+                {
+                  "@type": "owl:Restriction",
+                  "onProperty": "phyloref:excludes_TU",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                    "someValuesFrom": {
+                      "@type": "owl:Restriction",
+                      "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                      "hasValue": "Gavialis gangeticus"
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "label": "(Crocodylus niloticus ~ Gavialis gangeticus)"
+        }
+      ],
+      "equivalentClass": [
+        {
+          "@type": "owl:Class",
+          "intersectionOf": [
+            {
+              "@id": "http://example.org/brochu_2003.json#phyloref3_additional1"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "phyloref:excludes_TU",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Gavialis gangeticus"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@type": "owl:Class",
+          "intersectionOf": [
+            {
+              "@id": "http://example.org/brochu_2003.json#phyloref3_additional1"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000144",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Gavialis gangeticus"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@type": "owl:Class",
+          "intersectionOf": [
+            {
+              "@id": "http://example.org/brochu_2003.json#phyloref3_additional2"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "phyloref:excludes_TU",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Alligator mississippiensis"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@type": "owl:Class",
+          "intersectionOf": [
+            {
+              "@id": "http://example.org/brochu_2003.json#phyloref3_additional2"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000144",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Alligator mississippiensis"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Crocodylidae",
+      "cladeDefinition": "Crocodylidae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nLast common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.",
+      "internalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Tomistoma schlegelii",
+            "nameComplete": "Tomistoma schlegelii",
+            "genusPart": "Tomistoma",
+            "specificEpithet": "schlegelii"
+          }
+        },
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Osteolaemus tetraspis",
+            "nameComplete": "Osteolaemus tetraspis",
+            "genusPart": "Osteolaemus",
+            "specificEpithet": "tetraspis"
+          },
+          "label": "Osteolaemus tetraspis"
+        },
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+            "label": "Crocodylus niloticus",
+            "nameComplete": "Crocodylus niloticus",
+            "genusPart": "Crocodylus",
+            "specificEpithet": "niloticus"
+          },
+          "label": "Crocodylus niloticus"
+        }
+      ],
+      "externalSpecifiers": [],
+      "pso:holdsStatusInTime": [
+        {
+          "@type": "http://purl.org/spar/pso/StatusInTime",
+          "pso:withStatus": {
+            "@id": "pso:submitted"
+          },
+          "tvc:atTime": {
+            "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:51.960Z"
+          }
+        }
+      ],
+      "@id": "http://example.org/brochu_2003.json#phyloref4",
+      "@type": "owl:Class",
+      "subClassOf": "phyloref:Phyloreference",
+      "hasAdditionalClass": [],
+      "equivalentClass": [
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_lineage_to",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "obo:CDAO_0000149",
+                  "someValuesFrom": {
+                    "@type": "owl:Class",
+                    "intersectionOf": [
+                      {
+                        "@type": "owl:Restriction",
+                        "onProperty": "phyloref:excludes_TU",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                          "someValuesFrom": {
+                            "@type": "owl:Restriction",
+                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                            "hasValue": "Osteolaemus tetraspis"
+                          }
+                        }
+                      },
+                      {
+                        "@type": "owl:Restriction",
+                        "onProperty": "phyloref:includes_TU",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                          "someValuesFrom": {
+                            "@type": "owl:Restriction",
+                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                            "hasValue": "Crocodylus niloticus"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:includes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Tomistoma schlegelii"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_lineage_to",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "phyloref:includes_TU",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                    "someValuesFrom": {
+                      "@type": "owl:Restriction",
+                      "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                      "hasValue": "Crocodylus niloticus"
+                    }
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "obo:CDAO_0000149",
+                "someValuesFrom": {
+                  "@type": "owl:Class",
+                  "intersectionOf": [
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:excludes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Tomistoma schlegelii"
+                        }
+                      }
+                    },
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:includes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Osteolaemus tetraspis"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_lineage_to",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "phyloref:includes_TU",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                    "someValuesFrom": {
+                      "@type": "owl:Restriction",
+                      "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                      "hasValue": "Osteolaemus tetraspis"
+                    }
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "obo:CDAO_0000149",
+                "someValuesFrom": {
+                  "@type": "owl:Class",
+                  "intersectionOf": [
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:excludes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Tomistoma schlegelii"
+                        }
+                      }
+                    },
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:includes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Crocodylus niloticus"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_lineage_to",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "obo:CDAO_0000149",
+                  "someValuesFrom": {
+                    "@type": "owl:Class",
+                    "intersectionOf": [
+                      {
+                        "@type": "owl:Restriction",
+                        "onProperty": "phyloref:excludes_TU",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                          "someValuesFrom": {
+                            "@type": "owl:Restriction",
+                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                            "hasValue": "Tomistoma schlegelii"
+                          }
+                        }
+                      },
+                      {
+                        "@type": "owl:Restriction",
+                        "onProperty": "phyloref:includes_TU",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                          "someValuesFrom": {
+                            "@type": "owl:Restriction",
+                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                            "hasValue": "Crocodylus niloticus"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:includes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Osteolaemus tetraspis"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_lineage_to",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "phyloref:includes_TU",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                    "someValuesFrom": {
+                      "@type": "owl:Restriction",
+                      "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                      "hasValue": "Crocodylus niloticus"
+                    }
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "obo:CDAO_0000149",
+                "someValuesFrom": {
+                  "@type": "owl:Class",
+                  "intersectionOf": [
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:excludes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Osteolaemus tetraspis"
+                        }
+                      }
+                    },
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:includes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Tomistoma schlegelii"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_lineage_to",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "phyloref:includes_TU",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                    "someValuesFrom": {
+                      "@type": "owl:Restriction",
+                      "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                      "hasValue": "Tomistoma schlegelii"
+                    }
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "obo:CDAO_0000149",
+                "someValuesFrom": {
+                  "@type": "owl:Class",
+                  "intersectionOf": [
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:excludes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Osteolaemus tetraspis"
+                        }
+                      }
+                    },
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:includes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Crocodylus niloticus"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_lineage_to",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "obo:CDAO_0000149",
+                  "someValuesFrom": {
+                    "@type": "owl:Class",
+                    "intersectionOf": [
+                      {
+                        "@type": "owl:Restriction",
+                        "onProperty": "phyloref:excludes_TU",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                          "someValuesFrom": {
+                            "@type": "owl:Restriction",
+                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                            "hasValue": "Tomistoma schlegelii"
+                          }
+                        }
+                      },
+                      {
+                        "@type": "owl:Restriction",
+                        "onProperty": "phyloref:includes_TU",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                          "someValuesFrom": {
+                            "@type": "owl:Restriction",
+                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                            "hasValue": "Osteolaemus tetraspis"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:includes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Crocodylus niloticus"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_lineage_to",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "phyloref:includes_TU",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                    "someValuesFrom": {
+                      "@type": "owl:Restriction",
+                      "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                      "hasValue": "Osteolaemus tetraspis"
+                    }
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "obo:CDAO_0000149",
+                "someValuesFrom": {
+                  "@type": "owl:Class",
+                  "intersectionOf": [
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:excludes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Crocodylus niloticus"
+                        }
+                      }
+                    },
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:includes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Tomistoma schlegelii"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_lineage_to",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "phyloref:includes_TU",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                    "someValuesFrom": {
+                      "@type": "owl:Restriction",
+                      "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                      "hasValue": "Tomistoma schlegelii"
+                    }
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "obo:CDAO_0000149",
+                "someValuesFrom": {
+                  "@type": "owl:Class",
+                  "intersectionOf": [
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:excludes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Crocodylus niloticus"
+                        }
+                      }
+                    },
+                    {
+                      "@type": "owl:Restriction",
+                      "onProperty": "phyloref:includes_TU",
+                      "someValuesFrom": {
+                        "@type": "owl:Restriction",
+                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                        "someValuesFrom": {
+                          "@type": "owl:Restriction",
+                          "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                          "hasValue": "Osteolaemus tetraspis"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "title": "Phylogenetic Approaches Toward Crocodylian History",
+  "defaultNomenclaturalCodeURI": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+  "hasTaxonomicUnitMatches": [],
+  "@id": "http://example.org/brochu_2003.json#",
+  "@type": [
+    "testcase:PhyloreferenceTestCase",
+    "owl:Ontology"
+  ],
+  "owl:imports": [
+    "http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
+    "http://ontology.phyloref.org/2018-12-14/phyloref.owl",
+    "http://ontology.phyloref.org/2018-12-14/tcan.owl"
+  ]
+}


### PR DESCRIPTION
This PR will close #27 by allowing the base URI to be provided when converting a Phyx document to an OWL ontology in JSON-LD. In addition, it adds documentation in ESDoc format to PhyxWrapper, renames `asJSONLD`, which is confusing (the document is already a JSON-LD document) to `asOWLOntology`, and adds a test to ensure that the base URI is used in a predictable way when generating the ontology. This test converts a subset of our Brochu 2003 example file to an OWL ontology, and compares the OWL ontology generated with a previously generated file stored in this repository.