### PR TITLE
Add phyloref type to phyloreferences

### DIFF
--- a/docs/context/development/schema.json
+++ b/docs/context/development/schema.json
@@ -285,6 +285,14 @@
             "description": "The identifier of this clade definition in the Regnum database",
             "minLength": 1
           },
+          "phylorefType": {
+            "description": "The type of this phyloreference.",
+            "enum": [
+              "phyloref:PhyloreferenceUsingMaximumClade",
+              "phyloref:PhyloreferenceUsingMinimumClade",
+              "phyloref:PhyloreferenceUsingApomorphy"
+            ]
+          },
           "label": {
             "type": "string",
             "description": "The name or label of this phyloreference."

--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -688,7 +688,6 @@ class PhylorefWrapper {
 
     if (internalSpecifiers.length === 0) {
       // We can't handle phyloreferences without at least one internal specifier.
-      calculatedPhylorefType = 'phyloref:MalformedPhyloreference';
       phylorefAsJSONLD.malformedPhyloreference = 'No internal specifiers provided';
     } else if (externalSpecifiers.length > 0) {
       calculatedPhylorefType = 'phyloref:PhyloreferenceUsingMaximumClade';

--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -680,13 +680,19 @@ class PhylorefWrapper {
     PhylorefWrapper.componentClassesByLabel = {};
     phylorefAsJSONLD.hasComponentClass = [];
 
+    // The type of this phyloreference.
+    let calculatedPhylorefType;
+
     // The list of logical expressions generated for this phyloref.
     let logicalExpressions = [];
 
     if (internalSpecifiers.length === 0) {
       // We can't handle phyloreferences without at least one internal specifier.
+      calculatedPhylorefType = 'phyloref:MalformedPhyloreference';
       phylorefAsJSONLD.malformedPhyloreference = 'No internal specifiers provided';
     } else if (externalSpecifiers.length > 0) {
+      calculatedPhylorefType = 'phyloref:PhyloreferenceUsingMaximumClade';
+
       // If the phyloreference has at least one external specifier, we
       // can provide a simplified expression for the internal specifier,
       // in the form:
@@ -711,6 +717,8 @@ class PhylorefWrapper {
         );
       }
     } else {
+      calculatedPhylorefType = 'phyloref:PhyloreferenceUsingMinimumClade';
+
       // We only have internal specifiers. We therefore need to use the algorithm in
       // PhylorefWrapper.createClassExpressionsForInternals() to create this expression.
       logicalExpressions = PhylorefWrapper.createClassExpressionsForInternals(
@@ -772,8 +780,14 @@ class PhylorefWrapper {
     }
     phylorefAsJSONLD.subClassOf.push('phyloref:Phyloreference');
 
-    // Metadata.
-
+    // If the this Phyloref has a phylorefType that differs from the calculated
+    // phyloref type, throw an error.
+    if (has(phylorefAsJSONLD, 'phylorefType') && phylorefAsJSONLD.phylorefType !== calculatedPhylorefType) {
+      throw new Error(
+        `Phyloref ${this.label} has phylorefType set to '${phylorefAsJSONLD.phylorefType}', but it appears to be a '${calculatedPhylorefType}'.`
+      );
+    }
+    phylorefAsJSONLD.subClassOf.push(calculatedPhylorefType);
 
     return phylorefAsJSONLD;
   }

--- a/test/examples/correct/brochu_2003.json
+++ b/test/examples/correct/brochu_2003.json
@@ -45,6 +45,7 @@
     "phylorefs": [
         {
             "label": "Alligatoridae",
+            "phylorefType": "phyloref:PhyloreferenceUsingMinimumClade",
             "definition": "Alligatoridae (Cuvier 1807).\n\nLast common ancestor of Alligator mississippiensis and Caiman crocodilus and all of its descendents.",
             "definitionSource": {
               "type": "article",
@@ -121,6 +122,7 @@
         },
         {
             "label": "Alligatorinae",
+            "phylorefType": "phyloref:PhyloreferenceUsingMaximumClade",
             "definition": "Alligatorinae (Kälin 1940).\n\nAlligator mississippiensis and all crocodylians closer to it than to Caiman crocodilus.",
             "definitionSource": {
               "type": "article",
@@ -203,6 +205,7 @@
         },
         {
             "label": "Caimaninae",
+            "phylorefType": "phyloref:PhyloreferenceUsingMaximumClade",
             "definition": "Caimaninae (Norell 1988).\n\nCaiman crocodilus and all crocodylians closer to it than to Alligator mississippiensis.",
             "definitionSource": {
               "type": "article",
@@ -284,6 +287,7 @@
         },
         {
             "label": "Crocodyloidea",
+            "phylorefType": "phyloref:PhyloreferenceUsingMaximumClade",
             "definition": "Crocodyloidea (Fitzinger 1826).\n\nCrocodylus niloticus and all crocodylians closer to it than to Alligator mississippiensis or Gavialis gangeticus.",
             "internalSpecifiers": [
                 {
@@ -343,6 +347,7 @@
         },
         {
             "label": "Crocodylidae",
+            "phylorefType": "phyloref:PhyloreferenceUsingMinimumClade",
             "definition": "Crocodylidae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nLast common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.",
             "definitionSource": {
               "type": "article",
@@ -431,6 +436,7 @@
         },
         {
             "label": "Diplocynodontinae",
+            "phylorefType": "phyloref:PhyloreferenceUsingMaximumClade",
             "definition": "Diplocynodontinae (Brochu 1999).\n\nDiplocynodon ratelii and all crocodylians closer to it than to Alligator mississippiensis.",
             "definitionSource": {
               "type": "article",

--- a/test/examples/correct/brochu_2003.jsonld
+++ b/test/examples/correct/brochu_2003.jsonld
@@ -1286,6 +1286,7 @@
   "phylorefs": [
     {
       "label": "Alligatoridae",
+      "phylorefType": "phyloref:PhyloreferenceUsingMinimumClade",
       "definition": "Alligatoridae (Cuvier 1807).\n\nLast common ancestor of Alligator mississippiensis and Caiman crocodilus and all of its descendents.",
       "definitionSource": {
         "type": "article",
@@ -1403,11 +1404,13 @@
         }
       },
       "subClassOf": [
-        "phyloref:Phyloreference"
+        "phyloref:Phyloreference",
+        "phyloref:PhyloreferenceUsingMinimumClade"
       ]
     },
     {
       "label": "Alligatorinae",
+      "phylorefType": "phyloref:PhyloreferenceUsingMaximumClade",
       "definition": "Alligatorinae (Kälin 1940).\n\nAlligator mississippiensis and all crocodylians closer to it than to Caiman crocodilus.",
       "definitionSource": {
         "type": "article",
@@ -1527,11 +1530,13 @@
         ]
       },
       "subClassOf": [
-        "phyloref:Phyloreference"
+        "phyloref:Phyloreference",
+        "phyloref:PhyloreferenceUsingMaximumClade"
       ]
     },
     {
       "label": "Caimaninae",
+      "phylorefType": "phyloref:PhyloreferenceUsingMaximumClade",
       "definition": "Caimaninae (Norell 1988).\n\nCaiman crocodilus and all crocodylians closer to it than to Alligator mississippiensis.",
       "definitionSource": {
         "type": "article",
@@ -1650,11 +1655,13 @@
         ]
       },
       "subClassOf": [
-        "phyloref:Phyloreference"
+        "phyloref:Phyloreference",
+        "phyloref:PhyloreferenceUsingMaximumClade"
       ]
     },
     {
       "label": "Crocodyloidea",
+      "phylorefType": "phyloref:PhyloreferenceUsingMaximumClade",
       "definition": "Crocodyloidea (Fitzinger 1826).\n\nCrocodylus niloticus and all crocodylians closer to it than to Alligator mississippiensis or Gavialis gangeticus.",
       "internalSpecifiers": [
         {
@@ -1934,11 +1941,13 @@
         }
       ],
       "subClassOf": [
-        "phyloref:Phyloreference"
+        "phyloref:Phyloreference",
+        "phyloref:PhyloreferenceUsingMaximumClade"
       ]
     },
     {
       "label": "Crocodylidae",
+      "phylorefType": "phyloref:PhyloreferenceUsingMinimumClade",
       "definition": "Crocodylidae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nLast common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.",
       "definitionSource": {
         "type": "article",
@@ -2682,11 +2691,13 @@
         }
       ],
       "subClassOf": [
-        "phyloref:Phyloreference"
+        "phyloref:Phyloreference",
+        "phyloref:PhyloreferenceUsingMinimumClade"
       ]
     },
     {
       "label": "Diplocynodontinae",
+      "phylorefType": "phyloref:PhyloreferenceUsingMaximumClade",
       "definition": "Diplocynodontinae (Brochu 1999).\n\nDiplocynodon ratelii and all crocodylians closer to it than to Alligator mississippiensis.",
       "definitionSource": {
         "type": "article",
@@ -2806,7 +2817,8 @@
         ]
       },
       "subClassOf": [
-        "phyloref:Phyloreference"
+        "phyloref:Phyloreference",
+        "phyloref:PhyloreferenceUsingMaximumClade"
       ]
     }
   ],

--- a/test/examples/correct/brochu_2003.nq
+++ b/test/examples/correct/brochu_2003.nq
@@ -261,6 +261,7 @@
 <http://example.org/brochu_2003.json#phyloref0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <http://example.org/brochu_2003.json#phyloref0> <http://www.w3.org/2000/01/rdf-schema#label> "Alligatoridae" .
 <http://example.org/brochu_2003.json#phyloref0> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#Phyloreference> .
+<http://example.org/brochu_2003.json#phyloref0> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#PhyloreferenceUsingMinimumClade> .
 <http://example.org/brochu_2003.json#phyloref0> <http://www.w3.org/2002/07/owl#equivalentClass> _:b141 .
 <http://example.org/brochu_2003.json#phyloref1> <http://purl.obolibrary.org/obo/IAO_0000115> "Alligatorinae (Kälin 1940).\n\nAlligator mississippiensis and all crocodylians closer to it than to Caiman crocodilus." .
 <http://example.org/brochu_2003.json#phyloref1> <http://purl.obolibrary.org/obo/IAO_0000119> _:b149 .
@@ -270,6 +271,7 @@
 <http://example.org/brochu_2003.json#phyloref1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <http://example.org/brochu_2003.json#phyloref1> <http://www.w3.org/2000/01/rdf-schema#label> "Alligatorinae" .
 <http://example.org/brochu_2003.json#phyloref1> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#Phyloreference> .
+<http://example.org/brochu_2003.json#phyloref1> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#PhyloreferenceUsingMaximumClade> .
 <http://example.org/brochu_2003.json#phyloref1> <http://www.w3.org/2002/07/owl#equivalentClass> _:b156 .
 <http://example.org/brochu_2003.json#phyloref2> <http://purl.obolibrary.org/obo/IAO_0000115> "Caimaninae (Norell 1988).\n\nCaiman crocodilus and all crocodylians closer to it than to Alligator mississippiensis." .
 <http://example.org/brochu_2003.json#phyloref2> <http://purl.obolibrary.org/obo/IAO_0000119> _:b163 .
@@ -279,6 +281,7 @@
 <http://example.org/brochu_2003.json#phyloref2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <http://example.org/brochu_2003.json#phyloref2> <http://www.w3.org/2000/01/rdf-schema#label> "Caimaninae" .
 <http://example.org/brochu_2003.json#phyloref2> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#Phyloreference> .
+<http://example.org/brochu_2003.json#phyloref2> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#PhyloreferenceUsingMaximumClade> .
 <http://example.org/brochu_2003.json#phyloref2> <http://www.w3.org/2002/07/owl#equivalentClass> _:b170 .
 <http://example.org/brochu_2003.json#phyloref3> <http://purl.obolibrary.org/obo/IAO_0000115> "Crocodyloidea (Fitzinger 1826).\n\nCrocodylus niloticus and all crocodylians closer to it than to Alligator mississippiensis or Gavialis gangeticus." .
 <http://example.org/brochu_2003.json#phyloref3> <http://purl.org/spar/pso/holdsStatusInTime> _:b177 .
@@ -294,6 +297,7 @@
 <http://example.org/brochu_2003.json#phyloref3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <http://example.org/brochu_2003.json#phyloref3> <http://www.w3.org/2000/01/rdf-schema#label> "Crocodyloidea" .
 <http://example.org/brochu_2003.json#phyloref3> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#Phyloreference> .
+<http://example.org/brochu_2003.json#phyloref3> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#PhyloreferenceUsingMaximumClade> .
 <http://example.org/brochu_2003.json#phyloref3_component1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <http://example.org/brochu_2003.json#phyloref3_component1> <http://www.w3.org/2000/01/rdf-schema#label> "(Crocodylus niloticus ~ Alligator mississippiensis)" .
 <http://example.org/brochu_2003.json#phyloref3_component1> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#PhyloreferenceUsingMaximumClade> .
@@ -340,6 +344,7 @@
 <http://example.org/brochu_2003.json#phyloref4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <http://example.org/brochu_2003.json#phyloref4> <http://www.w3.org/2000/01/rdf-schema#label> "Crocodylidae" .
 <http://example.org/brochu_2003.json#phyloref4> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#Phyloreference> .
+<http://example.org/brochu_2003.json#phyloref4> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#PhyloreferenceUsingMinimumClade> .
 <http://example.org/brochu_2003.json#phyloref4_component1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <http://example.org/brochu_2003.json#phyloref4_component1> <http://www.w3.org/2000/01/rdf-schema#label> "(Crocodylus niloticus & Osteolaemus tetraspis & Tomistoma schlegelii)" .
 <http://example.org/brochu_2003.json#phyloref4_component1> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://example.org/brochu_2003.json#phyloref4> .
@@ -393,6 +398,7 @@
 <http://example.org/brochu_2003.json#phyloref5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <http://example.org/brochu_2003.json#phyloref5> <http://www.w3.org/2000/01/rdf-schema#label> "Diplocynodontinae" .
 <http://example.org/brochu_2003.json#phyloref5> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#Phyloreference> .
+<http://example.org/brochu_2003.json#phyloref5> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ontology.phyloref.org/phyloref.owl#PhyloreferenceUsingMaximumClade> .
 <http://example.org/brochu_2003.json#phyloref5> <http://www.w3.org/2002/07/owl#equivalentClass> _:b359 .
 _:b0 <http://purl.org/dc/terms/bibliographicCitation> "Christopher A. Brochu (2003) Phylogenetic approaches toward crocodylian history Annual Review of Earth and Planetary Sciences 31  fig 1 doi: 10.1146/annurev.earth.31.100901.141308 URL: https://www.annualreviews.org/doi/10.1146/annurev.earth.31.100901.141308" .
 _:b0 <http://purl.org/dc/terms/title> "Phylogenetic approaches toward crocodylian history" .


### PR DESCRIPTION
This PR adds a phyloreference type (`phylorefType`) to phyloreferences as defined in #6. The value of phylorefType must be one of the following classes from the Phyloref ontology:
- `phyloref:PhyloreferenceUsingMinimumClade` for minimum-clade phylorefs.
- `phyloref:PhyloreferenceUsingMaximumClade` for maximum-clade phylorefs.
- `phyloref:PhyloreferenceUsingApomorphy` for apomorphy-based phylorefs.

Separately, we calculate the phyloreference type while we are generating the logical expression (based on the internal and external specifiers), and make the phyloreference a subclass of that class. If the provided phylorefType differs from the computed phyloref type, we will throw an error and refuse to create this phyloreference.

Closes #6.