### PR TITLE
Add N-Quads output to phyx.js

### DIFF
--- a/bin/phyx2owl.js
+++ b/bin/phyx2owl.js
@@ -107,7 +107,7 @@ function convertFileToOWL(filename, argOutputFilename = "") {
 
     // Convert the Phyx file into JSON-LD.
     const wrappedPhyx = new phyx.PhyxWrapper(phyxContent);
-    wrappedPhyx.asNQuads(argv.baseIri, path.dirname(filename))
+    wrappedPhyx.toRDF(argv.baseIri, path.dirname(filename))
       .then(nquads => {
         fs.writeFileSync(
           outputFilename,

--- a/bin/phyx2owl.js
+++ b/bin/phyx2owl.js
@@ -5,7 +5,7 @@ const path = require('path');
 const phyx = require('..');
 
 /*
- * An application for converting input Phyx files to OWL ontologies.
+ * An application for converting input Phyx files to OWL ontologies in N-Quads.
  */
 
 // Read command line arguments.
@@ -107,12 +107,16 @@ function convertFileToOWL(filename, argOutputFilename = "") {
 
     // Convert the Phyx file into JSON-LD.
     const wrappedPhyx = new phyx.PhyxWrapper(phyxContent);
-    const owlOntology = wrappedPhyx.asOWLOntology(argv.baseIri);
-    const owlOntologyStr = JSON.stringify(owlOntology, null, 2);
-    fs.writeFileSync(
-      outputFilename,
-      owlOntologyStr
-    );
+    wrappedPhyx.asNQuads(argv.baseIri, path.dirname(filename))
+      .then(nquads => {
+        fs.writeFileSync(
+          outputFilename,
+          nquads
+        );
+      })
+      .catch(err => {
+        throw err;
+      });
 
     // Report on whether any phyloreferences were converted.
     if (filteredPhylorefs.length == 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
+        "jsonld": "^5.0.0",
         "lodash": "^4.17.20",
         "moment": "^2.27.0",
         "newick-js": "^1.1.1",
@@ -29,7 +30,6 @@
         "eslint-config-airbnb-base": "^13.2.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-mocha": "^5.3.0",
-        "jsonld": "^3.1.0",
         "mocha": "^5.2.0",
         "nodejs-file-downloader": "^4.1.1",
         "yargs": "^15.3.1"
@@ -59,6 +59,19 @@
         "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@digitalbazaar/http-client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.0.0.tgz",
+      "integrity": "sha512-BuaQ5DT1Fmdj178IAEOnWjgg8mmJPo5eEInS1pPOqDCItgFiUEdCR1KiR5Ey/oD+h1Zx0ozYQnP/a2Z7TCCKRg==",
+      "dependencies": {
+        "esm": "^3.2.22",
+        "ky": "^0.20.0",
+        "ky-universal": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@types/color-name": {
@@ -104,6 +117,17 @@
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
       "dev": true,
       "optional": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/acorn": {
       "version": "6.4.1",
@@ -234,6 +258,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -243,6 +268,7 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -275,6 +301,7 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -283,7 +310,8 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
@@ -459,6 +487,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -523,8 +552,7 @@
     "node_modules/canonicalize": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.5.tgz",
-      "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA==",
-      "dev": true
+      "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA=="
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -832,11 +860,20 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/debug": {
@@ -967,6 +1004,7 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -1647,6 +1685,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/espree": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
@@ -1725,11 +1771,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -1752,7 +1807,8 @@
       "dev": true,
       "engines": [
         "node >=0.6.0"
-      ]
+      ],
+      "optional": true
     },
     "node_modules/fast-deep-equal": {
       "version": "2.0.1",
@@ -1771,6 +1827,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fetch-blob": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-1.0.6.tgz",
+      "integrity": "sha512-XTotUY7hVtqdbHE0Ilm/u/nnXRv1T8nepxhMHzB885O0EkVvI05UlZq7rHQSd6hVDCNAGx4HTjbJO60Onjfckw==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/figures": {
       "version": "2.0.0",
@@ -1853,6 +1917,7 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -1952,6 +2017,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -2002,6 +2068,7 @@
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -2011,8 +2078,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
+      "optional": true,
       "dependencies": {
-        "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
       },
       "engines": {
@@ -2134,6 +2201,7 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -2164,7 +2232,6 @@
         "dom-serializer": "~0.1.0",
         "entities": "~1.1.1",
         "htmlparser2": "~3.8.1",
-        "jsdom": "^7.0.2",
         "lodash": "^4.1.0"
       },
       "engines": {
@@ -2392,18 +2459,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
@@ -2444,7 +2499,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -2461,7 +2517,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2486,7 +2543,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/jsdom": {
       "version": "7.2.2",
@@ -2545,7 +2603,8 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -2563,7 +2622,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/json5": {
       "version": "1.0.1",
@@ -2593,30 +2653,17 @@
       }
     },
     "node_modules/jsonld": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-3.2.0.tgz",
-      "integrity": "sha512-re7FofG1iklGDlAthC4u5AMMt4l3qRNQbSI0nZTJu9vJG2R0QO6/yIhh8ZIh/M9Gg+EjXsULgQV/HEsltoVZBg==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.0.0.tgz",
+      "integrity": "sha512-1fbd0VTgMT5maN5AhWoQhzbiXlij9giX3EseUw6dZbZRun1Mu7I0f+6WpyacBVfAcU215hxpgW+/ONgUNoCvdw==",
       "dependencies": {
+        "@digitalbazaar/http-client": "^1.0.0",
         "canonicalize": "^1.0.1",
-        "lru-cache": "^5.1.1",
-        "object.fromentries": "^2.0.2",
-        "rdf-canonize": "^1.0.2",
-        "request": "^2.88.0",
-        "semver": "^6.3.0",
-        "xmldom": "0.1.19"
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^2.0.1"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jsonld/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">=12"
       }
     },
     "node_modules/jsprim": {
@@ -2627,6 +2674,7 @@
       "engines": [
         "node >=0.6.0"
       ],
+      "optional": true,
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -2641,6 +2689,41 @@
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/ky": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.20.0.tgz",
+      "integrity": "sha512-JAfwtwj+t7WqRus88PfBj25aAjRQUgMhk7aB2ufjQ6v8faoNwMy02mfSQ0iNXWCbJGcSl2JZ5ckaiywRjbq0Uw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/ky-universal": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.7.0.tgz",
+      "integrity": "sha512-lJ39wTuCor/jcNqXd4jvNWw8Rq0eRYJqcof4sjF4aY0sfoj87aFiSKy1Vur7mQ8Jma29rG4qs6SRSeSVatKYlQ==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^3.0.0-beta.6-exportfix"
+      },
+      "engines": {
+        "node": ">=10.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky-universal?sponsor=1"
+      },
+      "peerDependencies": {
+        "ky": ">=0.17.0",
+        "web-streams-polyfill": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "web-streams-polyfill": {
+          "optional": true
+        }
       }
     },
     "node_modules/levn": {
@@ -2774,12 +2857,14 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/marked": {
@@ -2915,13 +3000,21 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "dev": true,
+    "node_modules/node-fetch": {
+      "version": "3.0.0-beta.6-exportfix",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.6-exportfix.tgz",
+      "integrity": "sha512-jhW2arLPAddi7q04JxlQtApqMQF8GxlGZV+wj5/WuDz3hpDTnAU9haJ5Fi2a0N3b4e728O4EIVACNq9nDCzLYw==",
+      "deprecated": "This release contains some TypeScript definition issues and we therefore recommend to update to the next version. Changelog: https://git.io/JfV1D",
+      "dependencies": {
+        "data-uri-to-buffer": "^3.0.0",
+        "fetch-blob": "^1.0.6"
+      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">=10.16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/nodejs-file-downloader": {
@@ -2977,6 +3070,7 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -3029,50 +3123,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.fromentries": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.3.tgz",
-      "integrity": "sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "has": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.fromentries/node_modules/es-abstract": {
-      "version": "1.18.0-next.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-      "dev": true,
-      "dependencies": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
-        "is-negative-zero": "^2.0.0",
-        "is-regex": "^1.1.1",
-        "object-inspect": "^1.8.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.1",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values": {
@@ -3272,7 +3322,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/pify": {
       "version": "2.3.0",
@@ -3330,7 +3381,8 @@
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
       "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -3356,13 +3408,12 @@
       "dev": true
     },
     "node_modules/rdf-canonize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.2.0.tgz",
-      "integrity": "sha512-MQdcRDz4+82nUrEb3hNQangBDpmep15uMmnWclGi/1KS0bNVc8oHpoNI0PFLHZsvwgwRzH31bO1JAScqUAstvw==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-2.0.1.tgz",
+      "integrity": "sha512-/GVELjrfW8G/wS4QfDZ5Kq68cS1belVNJqZlcwiErerexeBUsgOINCROnP7UumWIBNdeCwTVLE9NVXMnRYK0lA==",
       "dependencies": {
-        "node-forge": "^0.10.0",
-        "semver": "^6.3.0"
+        "semver": "^6.3.0",
+        "setimmediate": "^1.0.5"
       },
       "engines": {
         "node": ">=6"
@@ -3372,7 +3423,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3450,6 +3500,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -3480,13 +3531,15 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/request/node_modules/tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -3641,6 +3694,11 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
     "node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -3734,6 +3792,7 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -4062,6 +4121,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -4073,7 +4133,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -4135,6 +4196,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true,
+      "optional": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -4157,6 +4219,7 @@
       "engines": [
         "node >=0.6.0"
       ],
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -4314,25 +4377,15 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/xmldom": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1"
-      }
-    },
     "node_modules/y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "15.4.1",
@@ -4501,6 +4554,16 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@digitalbazaar/http-client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.0.0.tgz",
+      "integrity": "sha512-BuaQ5DT1Fmdj178IAEOnWjgg8mmJPo5eEInS1pPOqDCItgFiUEdCR1KiR5Ey/oD+h1Zx0ozYQnP/a2Z7TCCKRg==",
+      "requires": {
+        "esm": "^3.2.22",
+        "ky": "^0.20.0",
+        "ky-universal": "^0.7.0"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -4544,6 +4607,14 @@
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
       "dev": true,
       "optional": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "acorn": {
       "version": "6.4.1",
@@ -4649,6 +4720,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -4657,7 +4729,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -4680,13 +4753,15 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -4845,6 +4920,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -4900,8 +4976,7 @@
     "canonicalize": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.5.tgz",
-      "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA==",
-      "dev": true
+      "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -5171,9 +5246,15 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "debug": {
       "version": "3.1.0",
@@ -5282,6 +5363,7 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -5861,6 +5943,11 @@
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+    },
     "espree": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
@@ -5916,11 +6003,17 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "external-editor": {
       "version": "3.1.0",
@@ -5937,7 +6030,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fast-deep-equal": {
       "version": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -5955,6 +6049,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fetch-blob": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-1.0.6.tgz",
+      "integrity": "sha512-XTotUY7hVtqdbHE0Ilm/u/nnXRv1T8nepxhMHzB885O0EkVvI05UlZq7rHQSd6hVDCNAGx4HTjbJO60Onjfckw=="
     },
     "figures": {
       "version": "2.0.0",
@@ -6010,7 +6109,8 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "form-data": {
       "version": "2.3.3",
@@ -6089,6 +6189,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -6129,13 +6230,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -6236,6 +6339,7 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -6454,12 +6558,6 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
-    "is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-      "dev": true
-    },
     "is-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
@@ -6488,7 +6586,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -6505,7 +6604,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6527,7 +6627,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jsdom": {
       "version": "7.2.2",
@@ -6579,7 +6680,8 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -6597,7 +6699,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "json5": {
       "version": "1.0.1",
@@ -6626,26 +6729,14 @@
       }
     },
     "jsonld": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-3.2.0.tgz",
-      "integrity": "sha512-re7FofG1iklGDlAthC4u5AMMt4l3qRNQbSI0nZTJu9vJG2R0QO6/yIhh8ZIh/M9Gg+EjXsULgQV/HEsltoVZBg==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.0.0.tgz",
+      "integrity": "sha512-1fbd0VTgMT5maN5AhWoQhzbiXlij9giX3EseUw6dZbZRun1Mu7I0f+6WpyacBVfAcU215hxpgW+/ONgUNoCvdw==",
       "requires": {
+        "@digitalbazaar/http-client": "^1.0.0",
         "canonicalize": "^1.0.1",
-        "lru-cache": "^5.1.1",
-        "object.fromentries": "^2.0.2",
-        "rdf-canonize": "^1.0.2",
-        "request": "^2.88.0",
-        "semver": "^6.3.0",
-        "xmldom": "0.1.19"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^2.0.1"
       }
     },
     "jsprim": {
@@ -6653,6 +6744,7 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -6667,6 +6759,20 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "ky": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.20.0.tgz",
+      "integrity": "sha512-JAfwtwj+t7WqRus88PfBj25aAjRQUgMhk7aB2ufjQ6v8faoNwMy02mfSQ0iNXWCbJGcSl2JZ5ckaiywRjbq0Uw=="
+    },
+    "ky-universal": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.7.0.tgz",
+      "integrity": "sha512-lJ39wTuCor/jcNqXd4jvNWw8Rq0eRYJqcof4sjF4aY0sfoj87aFiSKy1Vur7mQ8Jma29rG4qs6SRSeSVatKYlQ==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^3.0.0-beta.6-exportfix"
       }
     },
     "levn": {
@@ -6788,12 +6894,11 @@
       }
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
       }
     },
     "marked": {
@@ -6898,11 +7003,14 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "dev": true
+    "node-fetch": {
+      "version": "3.0.0-beta.6-exportfix",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.6-exportfix.tgz",
+      "integrity": "sha512-jhW2arLPAddi7q04JxlQtApqMQF8GxlGZV+wj5/WuDz3hpDTnAU9haJ5Fi2a0N3b4e728O4EIVACNq9nDCzLYw==",
+      "requires": {
+        "data-uri-to-buffer": "^3.0.0",
+        "fetch-blob": "^1.0.6"
+      }
     },
     "nodejs-file-downloader": {
       "version": "4.1.1",
@@ -6953,7 +7061,8 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "object-inspect": {
       "version": "1.9.0",
@@ -6988,40 +7097,6 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5",
         "has": "^1.0.3"
-      }
-    },
-    "object.fromentries": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.3.tgz",
-      "integrity": "sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "has": "^1.0.3"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "object.values": {
@@ -7179,7 +7254,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pify": {
       "version": "2.3.0",
@@ -7225,7 +7301,8 @@
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
       "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "punycode": {
       "version": "2.1.1",
@@ -7245,20 +7322,18 @@
       "dev": true
     },
     "rdf-canonize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.2.0.tgz",
-      "integrity": "sha512-MQdcRDz4+82nUrEb3hNQangBDpmep15uMmnWclGi/1KS0bNVc8oHpoNI0PFLHZsvwgwRzH31bO1JAScqUAstvw==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-2.0.1.tgz",
+      "integrity": "sha512-/GVELjrfW8G/wS4QfDZ5Kq68cS1belVNJqZlcwiErerexeBUsgOINCROnP7UumWIBNdeCwTVLE9NVXMnRYK0lA==",
       "requires": {
-        "node-forge": "^0.10.0",
-        "semver": "^6.3.0"
+        "semver": "^6.3.0",
+        "setimmediate": "^1.0.5"
       },
       "dependencies": {
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -7320,6 +7395,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -7347,13 +7423,15 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tough-cookie": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -7482,6 +7560,11 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -7563,6 +7646,7 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -7849,6 +7933,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -7857,7 +7942,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -7909,7 +7995,8 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -7926,6 +8013,7 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -8058,22 +8146,15 @@
       "dev": true,
       "optional": true
     },
-    "xmldom": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw=",
-      "dev": true
-    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/phyloref/phyx.js#readme",
   "dependencies": {
+    "jsonld": "^5.0.0",
     "lodash": "^4.17.20",
     "moment": "^2.27.0",
     "newick-js": "^1.1.1",
@@ -49,7 +50,6 @@
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-mocha": "^5.3.0",
-    "jsonld": "^3.1.0",
     "mocha": "^5.2.0",
     "nodejs-file-downloader": "^4.1.1",
     "yargs": "^15.3.1"
@@ -62,7 +62,9 @@
         "name": "esdoc-standard-plugin",
         "option": {
           "manual": {
-            "files": [ "./CHANGELOG.md" ]
+            "files": [
+              "./CHANGELOG.md"
+            ]
           },
           "test": {
             "source": "./test/",

--- a/src/wrappers/PhyxWrapper.js
+++ b/src/wrappers/PhyxWrapper.js
@@ -259,7 +259,7 @@ class PhyxWrapper {
    * @return {Promise[string]} A Promise to return this Phyx document as a string that can
    *    be written to an N-Quads file.
    */
-  asNQuads(baseIRI = '', filePath = undefined) {
+  toRDF(baseIRI = '', filePath = undefined) {
     const owlJSONLD = this.asJSONLD(baseIRI);
 
     // For the purposes of testing, we are sometimes given a relative path to `@context`,

--- a/src/wrappers/PhyxWrapper.js
+++ b/src/wrappers/PhyxWrapper.js
@@ -1,6 +1,9 @@
 /** Helper methods from lodash. */
 const { has, cloneDeep, uniq } = require('lodash');
 
+/** For NQuads export. */
+const JSONLD = require('jsonld');
+
 const owlterms = require('../utils/owlterms');
 
 const { PhylorefWrapper } = require('./PhylorefWrapper');
@@ -60,7 +63,7 @@ class PhyxWrapper {
    *    prepending them with the baseIRI.
    * @return {Object} This Phyx document as an OWL ontology as a JSON-LD object.
    */
-  asOWLOntology(baseIRI = '') {
+  asJSONLD(baseIRI = '') {
     const jsonld = cloneDeep(this.phyx);
 
     // Some helper methods for generating base IRIs for phylorefs and phylogenies.
@@ -235,6 +238,24 @@ class PhyxWrapper {
     }
 
     return jsonld;
+  }
+
+  /**
+   * Generate an executable ontology from this Phyx document as N-Quads. Under the
+   * hood, we generate an OWL/JSON-LD representation of this Phyx document, and then
+   * convert it into N-Quads so that OWLAPI-supporting tools can directly consume it.
+   *
+   * @param {string} [baseIRI=""] - The base IRI to use when generating this Phyx document.
+   *    This should include a trailing '#' or '/'. Use '' to indicate that relative IDs
+   *    should be generated in the produced ontology (e.g. '#phylogeny1'). Note that if a
+   *    baseIRI is provided, then relative IDs already in the Phyx file (identified by an
+   *    initial '#') will be turned into absolute IDs by removing the initial `#` and
+   *    prepending them with the baseIRI.
+   * @return {Promise[string]} A Promise to return this Phyx document as a string that can
+   *    be written to an N-Quads file.
+   */
+  asNQuads(baseIRI = '') {
+    return JSONLD.toRDF(this.asJSONLD(baseIRI), { format: 'application/n-quads' });
   }
 }
 

--- a/test/examples.js
+++ b/test/examples.js
@@ -69,7 +69,7 @@ describe('PhyxWrapper', function () {
         it('should be able to convertible to an OWL Ontology', function () {
           this.timeout(10000);
           jsonld = new phyx.PhyxWrapper(json)
-            .asOWLOntology('http://example.org/phyx.js/example#');
+            .asJSONLD('http://example.org/phyx.js/example#');
           if (REPLACE_EXISTING) {
             fs.writeFileSync(
               jsonldFilename,

--- a/test/examples.js
+++ b/test/examples.js
@@ -87,7 +87,7 @@ describe('PhyxWrapper', function () {
           this.timeout(10000);
 
           return new phyx.PhyxWrapper(json)
-            .asNQuads('http://example.org/phyx.js/example#', path.resolve(__dirname, 'examples', 'correct'))
+            .toRDF('http://example.org/phyx.js/example#', path.resolve(__dirname, 'examples', 'correct'))
             .then((rdf) => {
               nq = rdf;
               if (REPLACE_EXISTING) fs.writeFileSync(nqFilename, nq);

--- a/test/examples.js
+++ b/test/examples.js
@@ -5,7 +5,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const JSONLD = require('jsonld');
 const chai = require('chai');
 const Ajv = require('ajv');
 
@@ -87,17 +86,13 @@ describe('PhyxWrapper', function () {
         it('should be convertible to n-quads', function () {
           this.timeout(10000);
 
-          // JSON-LD readers don't usually handle relative @context easily, so
-          // instead let's replace the entire @context with the local context file.
-          jsonld['@context'] = JSON.parse(fs.readFileSync(
-            path.resolve(__dirname, 'examples', 'correct', jsonld['@context'])
-          ));
-
-          return JSONLD.toRDF(jsonld, { format: 'application/n-quads' }).then((rdf) => {
-            nq = rdf;
-            if (REPLACE_EXISTING) fs.writeFileSync(nqFilename, nq);
-            expect(nq).to.be.a('string');
-          });
+          return new phyx.PhyxWrapper(json)
+            .asNQuads('http://example.org/phyx.js/example#', path.resolve(__dirname, 'examples', 'correct'))
+            .then((rdf) => {
+              nq = rdf;
+              if (REPLACE_EXISTING) fs.writeFileSync(nqFilename, nq);
+              expect(nq).to.be.a('string');
+            });
         });
 
         it('should generate the same n-quads ontology as it generated earlier', function () {

--- a/test/nomenclatural-codes.js
+++ b/test/nomenclatural-codes.js
@@ -135,7 +135,7 @@ describe('PhyxWrapper', function () {
       .to.include.key('defaultNomenclaturalCodeIRI');
     const defaultNomenclaturalCodeIRI = json.defaultNomenclaturalCodeIRI;
 
-    const jsonld = new phyx.PhyxWrapper(json).asOWLOntology();
+    const jsonld = new phyx.PhyxWrapper(json).asJSONLD();
 
     // Step 1. Check the phyloreferences. Neither specifier has a nomenclatural code,
     // but they should pick up the default nomenclatural code for the Phyx file.
@@ -209,7 +209,7 @@ describe('PhyxWrapper', function () {
     const inferredNomenCode = wrapped.defaultNomenCode;
     expect(inferredNomenCode).to.equal(owlterms.ICZN_CODE);
 
-    const jsonld = wrapped.asOWLOntology();
+    const jsonld = wrapped.asJSONLD();
 
     // Step 1. Check the phyloreferences. Since only *Caiman crocodilus* has a
     // nomenclatural code set, we should make sure that the other specifier


### PR DESCRIPTION
This PR replaces the  `PhyxWrapper.asOWLOntology()` with two methods: `PhyxWrapper.asJSONLD()` for converting a Phyx file into an OWL/JSON-LD file, and `PhyxWrapper.asNQuads()` for converting a Phyx file into an N-Quads file, which we do by converting the OWL/JSON-LD file into N-Quads using the [jsonld](https://www.npmjs.com/package/jsonld) NPM package. While the OWL/JSON-LD files are very useful in development, debugging and testing, we anticipate that most users will use `PhyxWrapper.asNQuads()` to directly produce N-Quads. It also modifies the `phyx2owl.js` script so that it produces N-Quad files rather than OWL/JSON-LD files.

Note that we use "N-Quads" instead of "N-Triples" because it is *possible* to set up a subgraph within a Phyx file using JSON-LD's [graph containers](https://w3c.github.io/json-ld-syntax/#graph-containers), in which case the `jsonld` NPM package we use should emit those graph IRIs in the N-Quads output. However, I don't know why anybody would do this, and in almost all cases the output we produce will be N-Triples rather than N-Quads. I think "N-Quads" is probably still the right term to use, since that format specifically says the graph IRI [may be left out if not needed](https://www.w3.org/TR/n-quads/#simple-triples). But I just wanted to be clear about that.

Should be merged after PR #87.