### PR TITLE
Changes link to tutorials to directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ entire Phyx file into a [JSON-LD] representation that can be reasoned over with
 an [OWL 2 DL] reasoner. See the [Phyloreference Curation Tool] or the [Clade Ontology]
 for examples of its usage.
 
-A [tutorial] demonstrating the use of phyx.js is available.
+[Tutorials demonstrating the use of phyx.js](./tutorials/) are available.
 
 ## Funding
 Funded by the US National Science Foundation through collaborative grants [DBI-1458484]
@@ -20,7 +20,6 @@ and [DBI-1458604]. See [Funding] for details.
   [OWL 2 DL]: https://www.w3.org/TR/owl2-overview/
   [Phyloreference Curation Tool]: https://github.com/phyloref/curation-tool
   [Clade Ontology]: https://github.com/phyloref/clade-ontology
-  [tutorial]: ./tutorials/Introduction.md
   [DBI-1458484]: http://www.nsf.gov/awardsearch/showAward?AWD_ID=1458484
   [DBI-1458604]: http://www.nsf.gov/awardsearch/showAward?AWD_ID=1458604
   [Funding]: http://www.phyloref.org/about/#funding


### PR DESCRIPTION
This was linked directly to the Markdown-conversion, which hides the directory-level README, which has useful information (including about using nbviewer).