### PR TITLE
Add citation and CITATION.CFF file for phyx.js

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ date-released: 2021-10-18
 identifiers:
   - type: doi
     value: 10.5281/zenodo.5576556
-    description: The concept DOI for JPhyloRef.
+    description: This DOI will always resolve to the latest version of phyx.js.
   - type: doi
     value: 10.5281/zenodo.5576557
     description: The versioned DOI for version 1.0.1 of phyx.js.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,37 @@
+cff-version: 1.2.0
+authors:
+  - family-names: Vaidya
+    given-names: Gaurav
+    orcid: https://orcid.org/0000-0003-0587-0454
+  - family-names: Lapp
+    given-names: Hilmar
+    orcid: https://orcid.org/0000-0001-9107-0714
+title: "phyx.js"
+type: software
+license: MIT
+version: v1.0.1
+date-released: 2021-10-18
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.5576556
+    description: The concept DOI for JPhyloRef.
+  - type: doi
+    value: 10.5281/zenodo.5576557
+    description: The versioned DOI for version 1.0.1 of phyx.js.
+url: "https://github.com/phyloref/phyx.js"
+repository-code: "https://github.com/phyloref/phyx.js"
+preferred-citation:
+  authors:
+    - family-names: Vaidya
+      given-names: Gaurav
+      orcid: https://orcid.org/0000-0003-0587-0454
+    - family-names: Cellinese
+      given-names: Nico
+      orcid: https://orcid.org/0000-0002-7157-9414
+    - family-names: Lapp
+      given-names: Hilmar
+      orcid: https://orcid.org/0000-0001-9107-0714
+  title: "A new phylogenetic data standard for computable clade definitions: the Phyloreference Exchange Format (Phyx)"
+  type: article
+  doi: 10.7717/peerj.12618
+  date-released: 2022-02-15

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # phyx.js
 
 [![Build Status](https://github.com/phyloref/phyx.js/workflows/Build%20and%20Test/badge.svg)](https://github.com/phyloref/phyx.js/actions?query=workflow%3A%22Build+and+Test%22)
+[![DOI](https://zenodo.org/badge/166467036.svg)](https://zenodo.org/badge/latestdoi/166467036)
 
 The Phyloreference Exchange (PHYX) format is a JSON representation that can be
 used to store and transfer definitions of [phyloreferences]. This library provides
@@ -10,6 +11,13 @@ an [OWL 2 DL] reasoner. See the [Phyloreference Curation Tool] or the [Clade Ont
 for examples of its usage.
 
 [Tutorials demonstrating the use of phyx.js](./tutorials/) are available.
+
+## Citation
+
+phyx.js should be cited by citing our publication documenting the Phyx format and phyx.js.
+
+> Vaidya G, Cellinese N, Lapp H. 2022. A new phylogenetic data standard for computable clade definitions: the
+> Phyloreference Exchange Format (Phyx) PeerJ 10:e12618 [doi:10.7717/peerj.12618](https://doi.org/10.7717/peerj.12618)
 
 ## Funding
 Funded by the US National Science Foundation through collaborative grants [DBI-1458484]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # phyx.js
 
 [![Build Status](https://github.com/phyloref/phyx.js/workflows/Build%20and%20Test/badge.svg)](https://github.com/phyloref/phyx.js/actions?query=workflow%3A%22Build+and+Test%22)
-[![DOI](https://zenodo.org/badge/166467036.svg)](https://zenodo.org/badge/latestdoi/166467036)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5576556.svg)](https://doi.org/10.5281/zenodo.5576556)
 
 The Phyloreference Exchange (PHYX) format is a JSON representation that can be
 used to store and transfer definitions of [phyloreferences]. This library provides


### PR DESCRIPTION
This PR adds a citation and a CITATION.CFF file for phyx.js. Closes #126.

Should be merged after PR #125.