### PR TITLE
Add curator notes to phylorefs and phylogenies

### DIFF
--- a/docs/context/development/phyx.json
+++ b/docs/context/development/phyx.json
@@ -116,8 +116,8 @@
       "@id": "phyloref:newick_expression",
       "@type": "xsd:string"
     },
-    "curator": {
-      "@id": "opentree:curatorName",
+    "curatorNotes": {
+      "@id": "obo:IAO_0000232",
       "@type": "xsd:string"
     },
     "scientificNameAuthorship": {

--- a/docs/context/development/schema.json
+++ b/docs/context/development/schema.json
@@ -469,6 +469,10 @@
           "additionalNodeProperties": {
             "type": "object",
             "description": "A dictionary mapping node labels to properties that should be added to the node when converting this Phyx file into an OWL ontology."
+          },
+          "curatorNotes": {
+            "type": "string",
+            "description": "Curator notes associated with this phylogeny."
           }
         }
       }
@@ -566,6 +570,10 @@
           "expectedResolution": {
             "type": "object",
             "description": "A dictionary of phylogeny identifiers to objects that record the nodeLabel (the node label on that phylogeny this phylogeny is expected to resolve to) as well as an optional description (describing why that node was chosen)."
+          },
+          "curatorNotes": {
+            "type": "string",
+            "description": "Curator notes associated with this phyloreference."
           }
         }
       }

--- a/test/examples.js
+++ b/test/examples.js
@@ -18,7 +18,7 @@ const expect = chai.expect;
 // If REPLACE_EXISTING is set to true, we replace the existing JSON-LD and N-Quads
 // files rather than comparing them -- not a good way to test, but useful when
 // the output has changed.
-const REPLACE_EXISTING = true;
+const REPLACE_EXISTING = false;
 
 /**
  * Test whether conversion of Phyx files to an OWL ontology occurs predictably.

--- a/test/examples.js
+++ b/test/examples.js
@@ -18,7 +18,7 @@ const expect = chai.expect;
 // If REPLACE_EXISTING is set to true, we replace the existing JSON-LD and N-Quads
 // files rather than comparing them -- not a good way to test, but useful when
 // the output has changed.
-const REPLACE_EXISTING = false;
+const REPLACE_EXISTING = true;
 
 /**
  * Test whether conversion of Phyx files to an OWL ontology occurs predictably.

--- a/test/examples/correct/brochu_2003.json
+++ b/test/examples/correct/brochu_2003.json
@@ -31,6 +31,7 @@
       "newick": "(Parasuchia,(rauisuchians,Aetosauria,(sphenosuchians,(protosuchians,(mesosuchians,(Hylaeochampsa,Aegyptosuchus,Stomatosuchus,(Allodaposuchus,('Gavialis gangeticus',(('Diplocynodon ratelii',('Alligator mississippiensis','Caiman crocodilus')Alligatoridae)Alligatoroidea,('Tomistoma schlegelii',('Osteolaemus tetraspis','Crocodylus niloticus')Crocodylinae)Crocodylidae)Brevirostres)Crocodylia))Eusuchia)Mesoeucrocodylia)Crocodyliformes)Crocodylomorpha))root;",
       "label": "Fig 1 from Brochu 2003",
       "@id": "#phylogeny0",
+      "curatorNotes": "The figure differentiates between clade definitions that resolve to nodes and those that resolve to branches; this distinction has been ignored here.",
       "source": {
         "type": "article",
         "title": "Phylogenetic approaches toward crocodylian history",
@@ -361,6 +362,7 @@
         "bibliographicCitation": "(Cuvier 1807)"
       },
       "phylorefType": "phyloref:PhyloreferenceUsingMinimumClade",
+      "curatorNotes": "An alternate definition of this phyloreference in the context of the molecular tree is included with the publication, but not included in this file. This defines Crocodylidae as the last common ancestor of Crocodylus niloticus and Osteolaemus tetraspis and all of its descendents.",
       "definition": "Crocodylidae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nLast common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.",
       "definitionSource": {
         "type": "article",

--- a/test/examples/correct/brochu_2003.jsonld
+++ b/test/examples/correct/brochu_2003.jsonld
@@ -32,6 +32,7 @@
       "newick": "(Parasuchia,(rauisuchians,Aetosauria,(sphenosuchians,(protosuchians,(mesosuchians,(Hylaeochampsa,Aegyptosuchus,Stomatosuchus,(Allodaposuchus,('Gavialis gangeticus',(('Diplocynodon ratelii',('Alligator mississippiensis','Caiman crocodilus')Alligatoridae)Alligatoroidea,('Tomistoma schlegelii',('Osteolaemus tetraspis','Crocodylus niloticus')Crocodylinae)Crocodylidae)Brevirostres)Crocodylia))Eusuchia)Mesoeucrocodylia)Crocodyliformes)Crocodylomorpha))root;",
       "label": "Fig 1 from Brochu 2003",
       "@id": "http://example.org/phyx.js/example#phylogeny0",
+      "curatorNotes": "The figure differentiates between clade definitions that resolve to nodes and those that resolve to branches; this distinction has been ignored here.",
       "source": {
         "type": "article",
         "title": "Phylogenetic approaches toward crocodylian history",
@@ -2263,6 +2264,7 @@
         "bibliographicCitation": "(Cuvier 1807)"
       },
       "phylorefType": "phyloref:PhyloreferenceUsingMinimumClade",
+      "curatorNotes": "An alternate definition of this phyloreference in the context of the molecular tree is included with the publication, but not included in this file. This defines Crocodylidae as the last common ancestor of Crocodylus niloticus and Osteolaemus tetraspis and all of its descendents.",
       "definition": "Crocodylidae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nLast common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.",
       "definitionSource": {
         "type": "article",

--- a/test/examples/correct/brochu_2003.nq
+++ b/test/examples/correct/brochu_2003.nq
@@ -1,5 +1,6 @@
 <http://example.org/phyx.js/example#phylogeny0> <http://ontology.phyloref.org/phyloref.owl#newick_expression> "(Parasuchia,(rauisuchians,Aetosauria,(sphenosuchians,(protosuchians,(mesosuchians,(Hylaeochampsa,Aegyptosuchus,Stomatosuchus,(Allodaposuchus,('Gavialis gangeticus',(('Diplocynodon ratelii',('Alligator mississippiensis','Caiman crocodilus')Alligatoridae)Alligatoroidea,('Tomistoma schlegelii',('Osteolaemus tetraspis','Crocodylus niloticus')Crocodylinae)Crocodylidae)Brevirostres)Crocodylia))Eusuchia)Mesoeucrocodylia)Crocodyliformes)Crocodylomorpha))root;" .
 <http://example.org/phyx.js/example#phylogeny0> <http://purl.obolibrary.org/obo/CDAO_0000148> <http://example.org/phyx.js/example#phylogeny0_node0> .
+<http://example.org/phyx.js/example#phylogeny0> <http://purl.obolibrary.org/obo/IAO_0000232> "The figure differentiates between clade definitions that resolve to nodes and those that resolve to branches; this distinction has been ignored here." .
 <http://example.org/phyx.js/example#phylogeny0> <http://purl.org/dc/terms/source> _:b180 .
 <http://example.org/phyx.js/example#phylogeny0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ontology.phyloref.org/phyloref.owl#ReferencePhylogenyEvidence> .
 <http://example.org/phyx.js/example#phylogeny0> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> _:b0 .
@@ -288,6 +289,7 @@
 <http://example.org/phyx.js/example#phyloref3_component2> <http://www.w3.org/2002/07/owl#equivalentClass> _:b238 .
 <http://example.org/phyx.js/example#phyloref4> <http://purl.obolibrary.org/obo/IAO_0000115> "Crocodylidae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nLast common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents." .
 <http://example.org/phyx.js/example#phyloref4> <http://purl.obolibrary.org/obo/IAO_0000119> _:b436 .
+<http://example.org/phyx.js/example#phyloref4> <http://purl.obolibrary.org/obo/IAO_0000232> "An alternate definition of this phyloreference in the context of the molecular tree is included with the publication, but not included in this file. This defines Crocodylidae as the last common ancestor of Crocodylus niloticus and Osteolaemus tetraspis and all of its descendents." .
 <http://example.org/phyx.js/example#phyloref4> <http://rs.tdwg.org/dwc/terms/scientificNameAuthorship> _:b437 .
 <http://example.org/phyx.js/example#phyloref4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <http://example.org/phyx.js/example#phyloref4> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> _:b0 .


### PR DESCRIPTION
Adds a curatorNotes field to phylorefs and phylogenies, and updates an example to demonstrate its use. I opted to map this field to [`IAO:0000232` "curator note"](http://purl.obolibrary.org/obo/IAO_0000232) so that it is included in the OWL output. Closes #122.

Should be merged after #128.