### PR TITLE
Guarded accessing phyloref.internalSpecifiers/externalSpecifiers

### DIFF
--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -25,7 +25,7 @@ class PhylorefWrapper {
   /** Return the internal specifiers of this phyloref (if any). */
   get internalSpecifiers() {
     if (!has(this.phyloref, 'internalSpecifiers')) {
-      this.phyloref.internalSpecifiers = [];
+      return [];
     }
 
     return this.phyloref.internalSpecifiers;
@@ -34,7 +34,7 @@ class PhylorefWrapper {
   /** Return the external specifiers of this phyloref (if any). */
   get externalSpecifiers() {
     if (!has(this.phyloref, 'externalSpecifiers')) {
-      this.phyloref.externalSpecifiers = [];
+      return [];
     }
 
     return this.phyloref.externalSpecifiers;

--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -25,7 +25,9 @@ class PhylorefWrapper {
   /** Return the internal specifiers of this phyloref (if any). */
   get internalSpecifiers() {
     if (!has(this.phyloref, 'internalSpecifiers')) {
-      return [];
+      // If there isn't one, create an empty list so that the caller can do
+      // `wrappedPhyloref.internalSpecifiers.push({...})`.
+      this.phyloref.internalSpecifiers = [];
     }
 
     return this.phyloref.internalSpecifiers;
@@ -34,7 +36,9 @@ class PhylorefWrapper {
   /** Return the external specifiers of this phyloref (if any). */
   get externalSpecifiers() {
     if (!has(this.phyloref, 'externalSpecifiers')) {
-      return [];
+      // If there isn't one, create an empty list so that the caller can do
+      // `wrappedPhyloref.externalSpecifiers.push({...})`.
+      this.phyloref.externalSpecifiers = [];
     }
 
     return this.phyloref.externalSpecifiers;

--- a/src/wrappers/PhylorefWrapper.js
+++ b/src/wrappers/PhylorefWrapper.js
@@ -114,11 +114,15 @@ class PhylorefWrapper {
     // it doesn't remember if the specifier to be deleted is internal
     // or external. We delete the intended specifier from both arrays.
 
-    let index = this.phyloref.internalSpecifiers.indexOf(specifier);
-    if (index !== -1) this.phyloref.internalSpecifiers.splice(index, 1);
+    if (has(this.phyloref, 'internalSpecifiers') && this.phyloref.internalSpecifiers.length > 0) {
+      const index = this.phyloref.internalSpecifiers.indexOf(specifier);
+      if (index !== -1) this.phyloref.internalSpecifiers.splice(index, 1);
+    }
 
-    index = this.phyloref.externalSpecifiers.indexOf(specifier);
-    if (index !== -1) this.phyloref.externalSpecifiers.splice(index, 1);
+    if (has(this.phyloref, 'externalSpecifiers') && this.phyloref.externalSpecifiers.length > 0) {
+      const index = this.phyloref.externalSpecifiers.indexOf(specifier);
+      if (index !== -1) this.phyloref.externalSpecifiers.splice(index, 1);
+    }
   }
 
   getExpectedNodeLabels(phylogeny) {


### PR DESCRIPTION
While working on Klados, I discovered that some uses of `phyloref.internalSpecifiers`/`phyloref.externalSpecifiers` are not guarded: we access those variables without checking to see if they exist. Generally this causes an error that is simply ignored. But since it is an easy fix, I went ahead and fixed them in this PR.

Should be merged after PR #127.