### PR TITLE
Replaced dwc:basisOfRecord to basisOfRecord

### DIFF
--- a/src/utils/owlterms.js
+++ b/src/utils/owlterms.js
@@ -11,9 +11,6 @@ module.exports = {
   // Phyloref properties.
   PHYLOREF_INCLUDES_TU: 'phyloref:includes_TU',
   PHYLOREF_EXCLUDES_TU: 'phyloref:excludes_TU',
-  PHYLOREF_EXCLUDES_LINEAGE_TO: 'phyloref:excludes_lineage_to',
-  TU_HAS_NAME_PROP: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
-  TU_SPECIMEN_PROP: 'dwc:organismID',
 
   // Terms from RDF
   RDF_TYPE: 'rdf:type',

--- a/src/wrappers/SpecimenWrapper.js
+++ b/src/wrappers/SpecimenWrapper.js
@@ -57,12 +57,12 @@ class SpecimenWrapper {
   static fromOccurrenceID(occurrenceID, basisOfRecord = 'PreservedSpecimen') {
     // Copy the occurrence ID so we can truncate it if necessary.
     let occurID = occurrenceID;
-    if (occurID.startsWith('urn:catalog:')) occurID = occurID.substr(12);
+    if (occurID.startsWith('urn:catalog:')) occurID = occurID.substring(12);
 
     // Prepare the specimen.
     const specimen = {
       '@type': SpecimenWrapper.TYPE_SPECIMEN,
-      basisOfRecord: basisOfRecord,
+      basisOfRecord,
       occurrenceID: occurID,
     };
 

--- a/src/wrappers/SpecimenWrapper.js
+++ b/src/wrappers/SpecimenWrapper.js
@@ -10,8 +10,8 @@ const { PhyxCacheManager } = require('../utils/PhyxCacheManager');
  *
  * - TaxonomicUnitWrapper.TYPE_SPECIMEN: A specimen.
  *    - Based on http://rs.tdwg.org/dwc/terms/Occurrence
- *    - Should have a dwc:occurrenceID with the occurrence identifier.
- *    - Should have a dwc:basisOfRecord to indicate what sort of occurrence this is.
+ *    - Should have a occurrenceID with the occurrence identifier.
+ *    - Should have a basisOfRecord to indicate what sort of occurrence this is.
  *
  * Since TaxonNameWrapper follows the TDWG ontology, we'd love to do the same for
  * SpecimenWrapper, but unfortunately the TaxonOccurrence ontology has been deprecated
@@ -38,7 +38,7 @@ class SpecimenWrapper {
     const normalizedSpecimen = {
       '@type': SpecimenWrapper.TYPE_SPECIMEN,
       label: wrapped.label,
-      'dwc:basisOfRecord': wrapped.basisOfRecord,
+      basisOfRecord: wrapped.basisOfRecord,
       occurrenceID: wrapped.occurrenceID,
       catalogNumber: wrapped.catalogNumber,
       institutionCode: wrapped.institutionCode,
@@ -62,7 +62,7 @@ class SpecimenWrapper {
     // Prepare the specimen.
     const specimen = {
       '@type': SpecimenWrapper.TYPE_SPECIMEN,
-      'dwc:basisOfRecord': basisOfRecord,
+      basisOfRecord: basisOfRecord,
       occurrenceID: occurID,
     };
 
@@ -185,7 +185,7 @@ class SpecimenWrapper {
    * Return the basis of record, if one is present.
    */
   get basisOfRecord() {
-    if (has(this.specimen, 'dwc:basisOfRecord')) return this.specimen['dwc:basisOfRecord'];
+    if (has(this.specimen, 'basisOfRecord')) return this.specimen.basisOfRecord;
     return undefined;
   }
 
@@ -194,7 +194,7 @@ class SpecimenWrapper {
    * recommended values.
    */
   set basisOfRecord(bor) {
-    this.specimen['dwc:basisOfRecord'] = bor;
+    this.specimen.basisOfRecord = bor;
   }
 
   /** Return this specimen as a taxon concept if it contains taxon name information. */

--- a/test/scripts/resolve.js
+++ b/test/scripts/resolve.js
@@ -62,15 +62,15 @@ describe('bin/resolve.js', function () {
     ]);
 
     expect(resultObj.Alligatoridae[0].resolved).to.include({
-      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree14.9@ott195670',
+      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree15.1@ott195670',
       label: 'Alligatoridae',
     });
     expect(resultObj.Alligatorinae[0].resolved).to.include({
-      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree14.9@ott151255',
+      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree15.1@ott151255',
       label: 'Alligatorinae',
     });
     expect(resultObj.Crocodylidae[0].resolved).to.include({
-      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree14.9@ott1092501',
+      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree15.1@ott1092501',
       label: 'Longirostres',
     });
     expect(resultObj.Diplocynodontinae[0]).to.include({

--- a/test/specimens.js
+++ b/test/specimens.js
@@ -24,7 +24,7 @@ describe('SpecimenWrapper', function () {
     it('should be able to extract an occurenceID and catalogNumber from simple specimen IDs', function () {
       const wrapper = new phyx.SpecimenWrapper({
         occurrenceID: 'Wall 2527, Fiji (uc)',
-        'dwc:basisOfRecord': 'PreservedSpecimen',
+        basisOfRecord: 'PreservedSpecimen',
       });
       expect(wrapper.occurrenceID).to.equal('Wall 2527, Fiji (uc)');
       expect(wrapper.catalogNumber).to.equal('Wall 2527, Fiji (uc)');
@@ -33,7 +33,7 @@ describe('SpecimenWrapper', function () {
     it('should extract institutionCode and catalogNumber from a institutionCode:catalogNumber combination', function () {
       const wrapper = new phyx.SpecimenWrapper({
         occurrenceID: 'FMNH:PR 2081',
-        'dwc:basisOfRecord': 'PreservedSpecimen',
+        basisOfRecord: 'PreservedSpecimen',
       });
       expect(wrapper.occurrenceID).to.equal('FMNH:PR 2081');
       expect(wrapper.institutionCode).to.equal('FMNH');
@@ -80,7 +80,7 @@ describe('SpecimenWrapper', function () {
       expect(specimen.institutionCode).to.equal('FMNH');
       expect(specimen.collectionCode).to.equal('PR');
       expect(specimen.catalogNumber).to.equal('2081');
-      expect(specimen['dwc:basisOfRecord']).to.equal('PreservedSpecimen');
+      expect(specimen.basisOfRecord).to.equal('PreservedSpecimen');
     });
   });
 });


### PR DESCRIPTION
Some parts of the code assumes that the basisOfRecord should be `dwc:basisOfRecord`, but [our publication](https://peerj.com/articles/12618/#fig-2) says that it should be `basisOfRecord`. This PR standardizes it to the form used in the publication.

I think we previously had dwc: prefixes everywhere, but we didn't notice that this was still around for basisOfRecord until just now. I've removed some redundant variables from `owlterms.py` (one of which had a dwc: prefix, which is how I found it). To get the tests to pass, I had to update the version number of Open Tree of Life nodes we used in one test.