### PR TITLE
Add links to our npmjs URL

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,6 +20,7 @@ identifiers:
     description: The versioned DOI for version 1.1.1 of phyx.js.
 url: "https://github.com/phyloref/phyx.js"
 repository-code: "https://github.com/phyloref/phyx.js"
+repository-artifact: "https://www.npmjs.com/package/@phyloref/phyx"
 preferred-citation:
   authors:
     - family-names: Vaidya

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,38 +1,48 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
 cff-version: 1.2.0
+title: phyx.js
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
 authors:
   - family-names: Vaidya
     given-names: Gaurav
-    orcid: https://orcid.org/0000-0003-0587-0454
+    orcid: 'https://orcid.org/0000-0003-0587-0454'
   - family-names: Lapp
     given-names: Hilmar
-    orcid: https://orcid.org/0000-0001-9107-0714
-title: "phyx.js"
-type: software
-license: MIT
-version: v1.1.1
-date-released: 2023-08-16
+    orcid: 'https://orcid.org/0000-0001-9107-0714'
 identifiers:
   - type: doi
     value: 10.5281/zenodo.5576556
-    description: This DOI will always resolve to the latest version of phyx.js.
+    description: >-
+      This DOI will always resolve to the latest version of
+      phyx.js.
   - type: doi
     value: 10.5281/zenodo.8251445
     description: The versioned DOI for version 1.1.1 of phyx.js.
-url: "https://github.com/phyloref/phyx.js"
-repository-code: "https://github.com/phyloref/phyx.js"
-repository-artifact: "https://www.npmjs.com/package/@phyloref/phyx"
+repository-code: 'https://github.com/phyloref/phyx.js'
+url: 'https://github.com/phyloref/phyx.js'
+repository-artifact: 'https://www.npmjs.com/package/@phyloref/phyx'
+license: MIT
+version: v1.1.1
+date-released: '2023-08-16'
 preferred-citation:
   authors:
     - family-names: Vaidya
       given-names: Gaurav
-      orcid: https://orcid.org/0000-0003-0587-0454
+      orcid: 'https://orcid.org/0000-0003-0587-0454'
     - family-names: Cellinese
       given-names: Nico
-      orcid: https://orcid.org/0000-0002-7157-9414
+      orcid: 'https://orcid.org/0000-0002-7157-9414'
     - family-names: Lapp
       given-names: Hilmar
-      orcid: https://orcid.org/0000-0001-9107-0714
-  title: "A new phylogenetic data standard for computable clade definitions: the Phyloreference Exchange Format (Phyx)"
+      orcid: 'https://orcid.org/0000-0001-9107-0714'
+  title: >-
+    A new phylogenetic data standard for computable clade definitions: the
+    Phyloreference Exchange Format (Phyx)
   type: article
   doi: 10.7717/peerj.12618
-  date-released: 2022-02-15
+  date-released: "2022-02-15"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -45,4 +45,4 @@ preferred-citation:
     Phyloreference Exchange Format (Phyx)
   type: article
   doi: 10.7717/peerj.12618
-  date-released: "2022-02-15"
+  date-released: '2022-02-15'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/phyloref/phyx.js/workflows/Build%20and%20Test/badge.svg)](https://github.com/phyloref/phyx.js/actions?query=workflow%3A%22Build+and+Test%22)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5576556.svg)](https://doi.org/10.5281/zenodo.5576556)
+[![NPM Version](https://img.shields.io/npm/v/@phyloref/phyx)](https://www.npmjs.com/package/@phyloref/phyx)
 
 The Phyloreference Exchange (PHYX) format is a JSON representation that can be
 used to store and transfer definitions of [phyloreferences]. This library provides
@@ -9,6 +10,14 @@ classes to help interpret some parts of these files, and for transforming an
 entire Phyx file into a [JSON-LD] representation that can be reasoned over with
 an [OWL 2 DL] reasoner. See the [Phyloreference Curation Tool] or the [Clade Ontology]
 for examples of its usage.
+
+## Usage
+
+You can install [phyx.js using npm](https://www.npmjs.com/package/@phyloref/phyx):
+
+```shell
+$ npm install @phyloref/phyx
+```
 
 [Tutorials demonstrating the use of phyx.js](./tutorials/) are available.
 


### PR DESCRIPTION
This PR adds links to our npmjs URL in several places:
- To the README file as both a badge and a link, as well as the command line required to install it
- To the CITATION.cff file -- I also passed this through [cffinit](https://bit.ly/cffinit) and found a few formatting and typing issues, which I also fixed.