### PR TITLE
Correct empty occurenceID so that it is blank, not `urn:catalog:::`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "resolve": "bin/resolve.js"
       },
       "devDependencies": {
+        "@shinnn/eslint-config": "^7.0.0",
         "ajv": "^6.12.2",
         "chai": "^4.2.0",
         "esdoc": "^1.1.0",
@@ -181,6 +182,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@shinnn/eslint-config": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@shinnn/eslint-config/-/eslint-config-7.0.0.tgz",
+      "integrity": "sha512-Og+iJAaHTdV/0XfW4/Ry9wjoNxodRyruOQjmKIJ9Gf95/UPQfi3+N+YlvGn2vnzMke+JWY0xC4c8Yn/lTvDATw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "eslint-plugin-eslint-comments": "^3.1.2",
+        "eslint-plugin-no-use-extend-native": "^0.4.1",
+        "eslint-plugin-node": "^9.1.0",
+        "eslint-plugin-promise": "^4.2.1",
+        "is-resolvable": "^1.1.0",
+        "lodash": "^4.17.11"
       }
     },
     "node_modules/@types/concat-stream": {
@@ -1966,6 +1982,53 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/eslint-plugin-es": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.1.tgz",
+      "integrity": "sha512-5fa/gR2yR3NxQf+UXkeLeP8FBBl6tSgdrAz1+cF84v1FMM4twGwQoqTnn+QxFLcPOrF4pdKEJKDB/q9GoyJrCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-utils": "^1.4.2",
+        "regexpp": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6.5.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "engines": {
+        "node": ">=6.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
@@ -2091,6 +2154,70 @@
       },
       "peerDependencies": {
         "eslint": ">= 4.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-no-use-extend-native": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.4.1.tgz",
+      "integrity": "sha512-tDkHM0kvxU0M2TpLRKGfFrpWXctFdTDY7VkiDTLYDaX90hMSJKkr/FiWThEXvKV0Dvffut2Z0B9Y7+h/k6suiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-get-set-prop": "^1.0.0",
+        "is-js-type": "^2.0.0",
+        "is-obj-prop": "^1.0.0",
+        "is-proto-prop": "^2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-node": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-9.2.0.tgz",
+      "integrity": "sha512-2abNmzAH/JpxI4gEOwd6K8wZIodK3BmHbTxz4s79OIYwwIt2gkpEXlAouJXu4H1c9ySTnRso0tsuthSOZbUMlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-plugin-es": "^1.4.1",
+        "eslint-utils": "^1.4.2",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.16.0"
+      }
+    },
+    "node_modules/eslint-plugin-node/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint-plugin-node/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
+      "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eslint-scope": {
@@ -2629,6 +2756,16 @@
       "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/get-set-props": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-set-props/-/get-set-props-0.1.0.tgz",
+      "integrity": "sha512-7oKuKzAGKj0ag+eWZwcGw2fjiZ78tXnXQoBgY0aU7ZOxTu4bB7hSuQSDgtKy978EDH062P5FmD2EWiDpQS9K9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/get-stdin": {
@@ -3385,6 +3522,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/is-get-set-prop": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
+      "integrity": "sha512-DvAYZ1ZgGUz4lzxKMPYlt08qAUqyG9ckSg2pIjfvcQ7+pkVNUHk8yVLXOnCLe5WKXhLop8oorWFBJHpwWQpszQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-set-props": "^0.1.0",
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3395,6 +3543,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-js-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
+      "integrity": "sha512-Aj13l47+uyTjlQNHtXBV8Cji3jb037vxwMWCgopRR8h6xocgBGW3qG8qGlIOEmbXQtkKShKuBM9e8AA1OeQ+xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-types": "^1.0.0"
       }
     },
     "node_modules/is-negative-zero": {
@@ -3433,6 +3591,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-obj-prop": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
+      "integrity": "sha512-5Idb61slRlJlsAzi0Wsfwbp+zZY+9LXKUAZpvT/1ySw+NxKLRWfa0Bzj+wXI3fX5O9hiddm5c3DAaRSNP/yl2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^1.0.0",
+        "obj-props": "^1.0.0"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -3440,6 +3609,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-proto-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-proto-prop/-/is-proto-prop-2.0.0.tgz",
+      "integrity": "sha512-jl3NbQ/fGLv5Jhan4uX+Ge9ohnemqyblWVVCpAvtTQzNFvV2xhJq+esnkIbYQ9F1nITXoLfDDQLp7LBw/zzncg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^1.0.0",
+        "proto-props": "^2.0.0"
       }
     },
     "node_modules/is-regex": {
@@ -3457,6 +3637,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.3",
@@ -3572,6 +3759,16 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
       "dev": true
+    },
+    "node_modules/js-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/js-types/-/js-types-1.0.0.tgz",
+      "integrity": "sha512-bfwqBW9cC/Lp7xcRpug7YrXm0IVw+T9e3g4mCYnv0Pjr3zIzU9PCQElYU9oSGAWzXlbdl9X5SAMPejO9sxkeUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -3984,6 +4181,16 @@
         "get-func-name": "^2.0.1"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -4280,6 +4487,16 @@
       "optional": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/obj-props": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.4.0.tgz",
+      "integrity": "sha512-p7p/7ltzPDiBs6DqxOrIbtRdwxxVRBj5ROukeNb9RgA+fawhrz5n2hpNz8DDmYR//tviJSj7nUnlppGmONkjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -4621,6 +4838,16 @@
       "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "dependencies": {
         "asap": "~2.0.6"
+      }
+    },
+    "node_modules/proto-props": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/proto-props/-/proto-props-2.0.0.tgz",
+      "integrity": "sha512-2yma2tog9VaRZY2mn3Wq51uiSW4NcPYT1cQdBagwyrznrilKSZwIZ0UG3ZPL/mx+axEns0hE35T5ufOYZXEnBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/psl": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "yargs": "^15.4.1"
   },
   "devDependencies": {
+    "@shinnn/eslint-config": "^7.0.0",
     "ajv": "^6.12.2",
     "chai": "^4.2.0",
     "esdoc": "^1.1.0",

--- a/src/wrappers/SpecimenWrapper.js
+++ b/src/wrappers/SpecimenWrapper.js
@@ -57,7 +57,7 @@ class SpecimenWrapper {
   static fromOccurrenceID(occurrenceID, basisOfRecord = 'PreservedSpecimen') {
     // Copy the occurrence ID so we can truncate it if necessary.
     let occurID = occurrenceID;
-    if (occurID.startsWith('urn:catalog:')) occurID = occurID.substr(12);
+    if (occurID.startsWith('urn:catalog:')) occurID = occurID.substring(12);
 
     // Prepare the specimen.
     const specimen = {

--- a/src/wrappers/SpecimenWrapper.js
+++ b/src/wrappers/SpecimenWrapper.js
@@ -159,7 +159,7 @@ class SpecimenWrapper {
    */
   get occurrenceID() {
     // Return the occurrenceID if it exists.
-    if (has(this.specimen, 'occurrenceID') && this.specimen.occurrenceID.trim() !== '') {
+    if (has(this.specimen, 'occurrenceID')) {
       return this.specimen.occurrenceID.trim();
     }
 

--- a/test/scripts/resolve.js
+++ b/test/scripts/resolve.js
@@ -62,15 +62,15 @@ describe('bin/resolve.js', function () {
     ]);
 
     expect(resultObj.Alligatoridae[0].resolved).to.include({
-      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree14.9@ott195670',
+      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree15.1@ott195670',
       label: 'Alligatoridae',
     });
     expect(resultObj.Alligatorinae[0].resolved).to.include({
-      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree14.9@ott151255',
+      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree15.1@ott151255',
       label: 'Alligatorinae',
     });
     expect(resultObj.Crocodylidae[0].resolved).to.include({
-      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree14.9@ott1092501',
+      '@id': 'https://tree.opentreeoflife.org/opentree/argus/opentree15.1@ott1092501',
       label: 'Longirostres',
     });
     expect(resultObj.Diplocynodontinae[0]).to.include({

--- a/test/specimens.js
+++ b/test/specimens.js
@@ -21,6 +21,12 @@ describe('SpecimenWrapper', function () {
       expect(wrapped).to.be.an.instanceOf(phyx.SpecimenWrapper);
       expect(wrapped.occurrenceID).to.be.undefined;
     });
+    it('should be able to wrap a specimen with an empty occurenceID', function () {
+      const wrapped = new phyx.SpecimenWrapper(phyx.SpecimenWrapper.fromOccurrenceID(''));
+
+      expect(wrapped).to.be.an.instanceOf(phyx.SpecimenWrapper);
+      expect(wrapped.occurrenceID).to.equal('');
+    });
     it('should be able to extract an occurenceID and catalogNumber from simple specimen IDs', function () {
       const wrapper = new phyx.SpecimenWrapper({
         occurrenceID: 'Wall 2527, Fiji (uc)',


### PR DESCRIPTION
We previously ignored the occurrenceID if it was an empty string, and "constructed" an occurrenceID from the other components. This PR modifies that behavior so that an occurrenceID set to a blank string will be treated as an empty occurrenceID -- only a specimen missing an occurrenceID entirely will have one constructed based on the other components.  It also adds a test for this functionality.

It also replaces one use of `substr()` (now deprecated) with `substring()`, updates the OpenTree version in a test that would otherwise fail, and adds the `@shinnn/eslint-config` package, which is needed now for some reason.

Closes #145.