### PR TITLE
Add AGENTS.md and RELEASE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ All classes are exported from `src/index.js`. Each wraps a corresponding JSON ob
 
 | Wrapper | Purpose |
 |---|---|
-| `PhyxWrapper` | Top-level PHYX document; converts to JSON-LD, N-Quads, or normalized form |
+| `PhyxWrapper` | Top-level Phyx document; converts to JSON-LD, N-Quads, or normalized form |
 | `PhylorefWrapper` | Individual phyloreference; manages specifiers, status, OWL restrictions |
 | `PhylogenyWrapper` | Phylogeny tree; parses Newick strings, extracts taxonomic units from node labels |
 | `TaxonomicUnitWrapper` | Base for specimens and taxon concepts; extracts units from arbitrary strings |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ All classes are exported from `src/index.js`. Each wraps a corresponding JSON ob
 | `PhylorefWrapper` | Individual phyloreference; manages specifiers, status, OWL restrictions |
 | `PhylogenyWrapper` | Phylogeny tree; parses Newick strings, extracts taxonomic units from node labels |
 | `TaxonomicUnitWrapper` | Base for specimens and taxon concepts; extracts units from arbitrary strings |
-| `TaxonConceptWrapper` | Taxon concept with nomenclatural code and name components |
+| `TaxonConceptWrapper` | Taxon concept with nomenclatural code, taxonomic name and name components, and an optional citation |
 | `TaxonNameWrapper` | Parses scientific names (uninomial/binomial/trinomial) by nomenclatural code |
 | `SpecimenWrapper` | Specimen with occurrenceID, collection, and catalog number |
 | `CitationWrapper` | Bibliographic citation with authors and publication details |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ All classes are exported from `src/index.js`. Each wraps a corresponding JSON ob
 
 ```
 PHYX JSON file
-  └─▶ PhyxWrapper.asJSONLD() / asNQuads() / normalize()
+  └─▶ PhyxWrapper.asJSONLD() / toRDF() / PhyxWrapper.normalize(phyxDocument)
         ├─▶ PhylorefWrapper  (per phyloreference)
         │     └─▶ TaxonomicUnitWrapper → TaxonConceptWrapper | SpecimenWrapper
         └─▶ PhylogenyWrapper (per phylogeny)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,6 @@ PHYX JSON file
 
 ### Tooling
 
-- **Linter/formatter**: [Biomejs](https://biomejs.dev/) (`biome.json`) — single quotes, applied to `src/` and `bin/`; test files are excluded
+- **Linter/formatter**: [Biomejs](https://biomejs.dev/) (`biome.json`) — enforces single quotes and other style rules on `**/*.js`, `**/*.json`, and `**/*.md` (excluding `docs/`), with overrides that disable formatting/linting for test files
 - **Docs**: ESDoc, outputs to `docs/`
 - **CI**: GitHub Actions, Node 22/24/25, runs `npm test` (includes lint)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ All classes are exported from `src/index.js`. Each wraps a corresponding JSON ob
 | `TaxonNameWrapper` | Parses scientific names (uninomial/binomial/trinomial) by nomenclatural code |
 | `SpecimenWrapper` | Specimen with occurrenceID, collection, and catalog number |
 | `CitationWrapper` | Bibliographic citation with authors and publication details |
-| `TaxonomicUnitMatcher` | (`src/matchers/`) Matches taxonomic units across documents |
+| `TaxonomicUnitMatcher` | (`src/matchers/`) Provides an algorithm for matching two taxonomic units. |
 | `PhyxCacheManager` | (`src/utils/`) Caches computed values across the library |
 
 **Key utility:** `src/utils/owlterms.js` — canonical IRIs for OWL/RDF/CDAO/TDWG ontology terms used throughout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ npm run docs
 ### Core concepts
 
 - **Phyloreferences**: Clade definitions specifying which organisms belong to a clade, using internal/external specifiers
-- **Specifiers**: Organisms used to define a clade (internal = inside clade, external = outside)
+- **Specifiers**: Taxonomic units (taxa or specimens) or apomorphies used to define a clade (internal = inside clade, external = outside)
 - **Taxonomic Units**: Represent organisms, either as taxon concepts or specimens
 - **Phylogenies**: Newick-format trees providing resolution context for phyloreferences
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# AGENTS.md
+
+This file provides guidance to agents when working with code in this repository.
+
+## Commands
+
+```bash
+# Run all tests (linting runs automatically as posttest)
+npm test
+
+# Run linting only
+npm run lint
+
+# Run a specific test file
+npx mocha test/phylorefs.js
+
+# Run tests matching a description pattern
+npx mocha test/phylorefs.js --grep "PhylorefWrapper"
+
+# Generate API documentation
+npm run docs
+```
+
+## Architecture
+
+**phyx.js** is a JavaScript library for reading, manipulating, and converting [Phyloreference Exchange (Phyx)](https://doi.org/10.7717/peerj.12618) files — a JSON-LD format for digitized clade definitions (phyloreferences) with annotated phylogenies. This repository also includes the JSON Schema and JSON-LD files for Phyx, providing a definitive source of the format.
+
+### Core concepts
+
+- **Phyloreferences**: Clade definitions specifying which organisms belong to a clade, using internal/external specifiers
+- **Specifiers**: Organisms used to define a clade (internal = inside clade, external = outside)
+- **Taxonomic Units**: Represent organisms, either as taxon concepts or specimens
+- **Phylogenies**: Newick-format trees providing resolution context for phyloreferences
+
+### Module structure (`src/`)
+
+All classes are exported from `src/index.js`. Each wraps a corresponding JSON object from a PHYX file:
+
+| Wrapper | Purpose |
+|---|---|
+| `PhyxWrapper` | Top-level PHYX document; converts to JSON-LD, N-Quads, or normalized form |
+| `PhylorefWrapper` | Individual phyloreference; manages specifiers, status, OWL restrictions |
+| `PhylogenyWrapper` | Phylogeny tree; parses Newick strings, extracts taxonomic units from node labels |
+| `TaxonomicUnitWrapper` | Base for specimens and taxon concepts; extracts units from arbitrary strings |
+| `TaxonConceptWrapper` | Taxon concept with nomenclatural code and name components |
+| `TaxonNameWrapper` | Parses scientific names (uninomial/binomial/trinomial) by nomenclatural code |
+| `SpecimenWrapper` | Specimen with occurrenceID, collection, and catalog number |
+| `CitationWrapper` | Bibliographic citation with authors and publication details |
+| `TaxonomicUnitMatcher` | (`src/matchers/`) Matches taxonomic units across documents |
+| `PhyxCacheManager` | (`src/utils/`) Caches computed values across the library |
+
+**Key utility:** `src/utils/owlterms.js` — canonical IRIs for OWL/RDF/CDAO/TDWG ontology terms used throughout.
+
+### Data flow
+
+```
+PHYX JSON file
+  └─▶ PhyxWrapper.asJSONLD() / asNQuads() / normalize()
+        ├─▶ PhylorefWrapper  (per phyloreference)
+        │     └─▶ TaxonomicUnitWrapper → TaxonConceptWrapper | SpecimenWrapper
+        └─▶ PhylogenyWrapper (per phylogeny)
+              └─▶ Newick parser → node TaxonomicUnitWrappers
+```
+
+### CLI tools (`bin/`)
+
+- `bin/phyx2owl.mjs` — converts PHYX files to OWL ontologies (N-Quads)
+- `bin/resolve.mjs` — resolves phyloreferences against Open Tree of Life
+
+### Testing
+
+- Test files in `test/` mirror source modules (`phylorefs.js`, `phylogenies.js`, etc.)
+- `test/examples/correct/` contains fixture PHYX files with expected outputs used by `test/examples.js`
+- `test/jphyloref.js` requires the JPhyloRef JAR; may be skipped if Java is unavailable
+
+### Tooling
+
+- **Linter/formatter**: [Biomejs](https://biomejs.dev/) (`biome.json`) — single quotes, applied to `src/` and `bin/`; test files are excluded
+- **Docs**: ESDoc, outputs to `docs/`
+- **CI**: GitHub Actions, Node 22/24/25, runs `npm test` (includes lint)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,48 @@
+# Releasing phyx.js
+
+Steps to release a new version of phyx.js (e.g. `vX.Y.Z`).
+
+## 1. Prepare a release PR
+
+Create a branch named `release-phyx.js-vX.Y.Z` and open a PR against `master`.
+
+In the PR:
+
+1. **Update `CHANGELOG.md`** — move items from `[Unreleased]` into a new `[X.Y.Z] - YYYY-MM-DD` section.
+2. **Bump the version in `package.json`** to `X.Y.Z`.
+3. **Regenerate documentation** — run `npm run docs` and commit the updated `docs/` tree.
+4. Set the version in `package.json` to the final version (not an alpha) before merging.
+
+Get the PR reviewed and approved, then merge it.
+
+## 2. Publish to npm
+
+```bash
+npm publish --access public
+```
+
+Verify the new version appears at https://www.npmjs.com/package/@phyloref/phyx.
+
+## 3. Tag and release on GitHub
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Then create a GitHub release for the tag (via the GitHub UI or `gh release create vX.Y.Z`).
+
+## 4. Confirm the Zenodo deposit
+
+The GitHub release triggers an automatic Zenodo deposit. Check that a new versioned DOI has been minted at https://zenodo.org (search for "phyx.js").
+
+## 5. Update `CITATION.cff`
+
+Once the Zenodo DOI is available, update `CITATION.cff`:
+
+- `version`: `vX.Y.Z`
+- `date-released`: the release date (YYYY-MM-DD)
+- The versioned DOI identifier (`identifiers[1].value`): the new Zenodo DOI
+- Leave the concept DOI (`10.5281/zenodo.5576556`) unchanged — it always resolves to the latest version.
+
+Commit and push this change directly to `master` (or as a follow-up PR).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,4 +45,6 @@ Once the Zenodo DOI is available, update `CITATION.cff`:
 - The versioned DOI identifier (`identifiers[1].value`): the new Zenodo DOI
 - Leave the concept DOI (`10.5281/zenodo.5576556`) unchanged — it always resolves to the latest version.
 
-Commit and push this change directly to `master` (or as a follow-up PR).
+## 6. Merge PR
+
+Once all of the above steps have been successfully carried, merge the release PR.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,9 +9,9 @@ Create a branch named `release-phyx.js-vX.Y.Z` and open a PR against `master`.
 In the PR:
 
 1. **Update `CHANGELOG.md`** — move items from `[Unreleased]` into a new `[X.Y.Z] - YYYY-MM-DD` section.
-2. **Bump the version in `package.json`** to `X.Y.Z`.
+2. **Bump the version in `package.json`** to the final release version `X.Y.Z` (not an alpha) before merging.
 3. **Regenerate documentation** — run `npm run docs` and commit the updated `docs/` tree.
-4. Set the version in `package.json` to the final version (not an alpha) before merging.
+
 
 Get the PR reviewed and approved, then merge it.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,4 +47,4 @@ Once the Zenodo DOI is available, update `CITATION.cff`:
 
 ## 6. Merge PR
 
-Once all of the above steps have been successfully carried, merge the release PR.
+Once all of the above steps have been successfully carried out, merge the release PR.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ In the PR:
 3. **Regenerate documentation** — run `npm run docs` and commit the updated `docs/` tree.
 
 
-Get the PR reviewed and approved, then merge it.
+Get the PR reviewed and approved, but do NOT merge it until after successfully publishing it to NPM.
 
 ## 2. Publish to npm
 


### PR DESCRIPTION
This PR adds an AGENTS.md file (generated by Claude, which also needs a CLAUDE.md file I think). It also adds a RELEASE.md, which is based on an existing PR and documents how new releases of phyx.js should be made. Both files are intended to document the current state but to be modified in the future as that state changes.