### PR TITLE
Updated PHYX_CONTEXT_JSON to v1.1.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,8 +10,8 @@ In the PR:
 
 1. **Update `CHANGELOG.md`** — move items from `[Unreleased]` into a new `[X.Y.Z] - YYYY-MM-DD` section.
 2. **Bump the version in `package.json`** to the final release version `X.Y.Z` (not an alpha) before merging.
-3. **Update the PHYX_CONTEXT_JSON in `src/utils/owlterms.js`** to the latest version of the context. If the
-   context has not changed in this release, there is no need to update it.
+3. **Update the PHYX_CONTEXT_JSON in `src/utils/owlterms.js`** if a new version of the context has been
+   produced in this release.
 4. **Regenerate documentation** — run `npm run docs` and commit the updated `docs/` tree.
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,9 @@ In the PR:
 
 1. **Update `CHANGELOG.md`** — move items from `[Unreleased]` into a new `[X.Y.Z] - YYYY-MM-DD` section.
 2. **Bump the version in `package.json`** to the final release version `X.Y.Z` (not an alpha) before merging.
-3. **Regenerate documentation** — run `npm run docs` and commit the updated `docs/` tree.
+3. **Update the PHYX_CONTEXT_JSON in `src/utils/owlterms.js`** to the latest version of the context. If the
+   context has not changed in this release, there is no need to update it.
+4. **Regenerate documentation** — run `npm run docs` and commit the updated `docs/` tree.
 
 
 Get the PR reviewed and approved, but do NOT merge it until after successfully publishing it to NPM.

--- a/src/utils/owlterms.js
+++ b/src/utils/owlterms.js
@@ -1,7 +1,7 @@
 // Some OWL constants to be used.
 module.exports = {
   // Where is our context file located?
-  PHYX_CONTEXT_JSON: 'http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json',
+  PHYX_CONTEXT_JSON: 'http://www.phyloref.org/phyx.js/context/v1.1.0/phyx.json',
 
   // OWL properties.
   OWL_CLASS: 'owl:Class',


### PR DESCRIPTION
Apparently I failed to update the PHYX_CONTEXT_JSON in our owlterms.js file since we released Phyx v0.2.0. This PR updates it to the latest version ([Phyx v1.1.0](https://www.phyloref.org/phyx.js/context/)). This PR fixes that and notes the need for updating this variable whenever the context changes in [RELEASE.md](https://github.com/phyloref/phyx.js/blob/master/RELEASE.md). I've opened an issue to add an automated test in #170